### PR TITLE
feat(authors-info): refactor date cells to use DefaultCell with locale tooltip

### DIFF
--- a/packages/authors-info/src/ui/index.client.tsx
+++ b/packages/authors-info/src/ui/index.client.tsx
@@ -1,22 +1,37 @@
 'use client';
-import React, { Fragment } from 'react';
+import React from 'react';
 import moment from 'moment';
-import { useLocale } from '@payloadcms/ui'
+import { DefaultCell, useLocale } from '@payloadcms/ui'
+import type { DateFieldClient, DefaultCellComponentProps } from 'payload'
 
-export interface TableCellProps {
-  cellData: any;
-  fieldKey: 'createdAt' | 'updatedAt';
-}
+export type DateCellProps = DefaultCellComponentProps<DateFieldClient>
 
-export const CreatedAtCellClient: React.FC<TableCellProps> = (props) => {
-  const { cellData, fieldKey } = props;
-  const locale = useLocale()
+export const CreatedAtCellClient: React.FC<DateCellProps> = (props) => {
+  const locale = useLocale();
   moment.locale(locale.code);
 
-  // Ensure cellData is not null before passing it to moment
-  const validCellData = cellData?.rowData?.[fieldKey] ?? null;
+  // @ts-ignore
+  const rawDate = props?.cellData ?? props?.rowData?.createdAt ?? null;
+  const fullFormatted = rawDate ? moment(rawDate).format('LLLL') : '';
 
-  const fromNow = validCellData ? moment(validCellData,locale.code).fromNow() : 'N/A';
+  return (
+    <span title={fullFormatted}>
+      <DefaultCell {...props} />
+    </span>
+  );
+};
 
-  return <Fragment>{validCellData ? fromNow : 'N/A'}</Fragment>;
+export const UpdatedAtCellClient: React.FC<DateCellProps> = (props) => {
+  const locale = useLocale();
+  moment.locale(locale.code);
+
+  // @ts-ignore
+  const rawDate = props?.cellData ?? props?.rowData?.updatedAt ?? null;
+  const fullFormatted = rawDate ? moment(rawDate).format('LLLL') : '';
+
+  return (
+    <span title={fullFormatted}>
+      <DefaultCell {...props} />
+    </span>
+  );
 };

--- a/packages/authors-info/src/ui/index.tsx
+++ b/packages/authors-info/src/ui/index.tsx
@@ -2,12 +2,12 @@
 
 import React from 'react';
 
-import { TableCellProps, CreatedAtCellClient } from './index.client.js';
+import { CreatedAtCellClient, UpdatedAtCellClient } from './index.client.js';
 
 export const CreatedAtCell = (props) => {
-  return <CreatedAtCellClient cellData={props} fieldKey='createdAt' />;
+  return <CreatedAtCellClient {...props} />;
 };
 
 export const UpdatedAtCell = (props) => {
-  return <CreatedAtCellClient cellData={props} fieldKey='updatedAt' />;
+  return <UpdatedAtCellClient {...props} />;
 };


### PR DESCRIPTION
## Summary

Closes #92

Refactors `CreatedAtCell` and `UpdatedAtCell` in the `authors-info` package to use Payload's standard `DefaultCell` component pattern, with a tooltip showing the full locale-formatted datetime.

## Changes

- **`index.client.tsx`**: Replaced custom `cellData`/`fieldKey` prop pattern with standard `DefaultCellComponentProps<DateFieldClient>`. Each cell now wraps `<DefaultCell {...props} />` inside a `<span title={fullFormatted}>` where `fullFormatted` is `moment(date).format('LLLL')` respecting the current locale. Added `UpdatedAtCellClient` alongside `CreatedAtCellClient`.
- **`index.tsx`**: Simplified to pass props directly to the new client components (no more manual prop reshaping).

## Before / After

**Before:** Cells rendered relative time ("2 hours ago") with a custom prop wrapper.

**After:** Cells render the standard Payload date cell display, with a native tooltip on hover showing the full formatted datetime (e.g. "Tuesday, May 5, 2026 7:53 AM") according to the active locale.
