### PR TITLE
feat(custom-version-view): make updatedBy/createdBy/process field names configurable (#45)

### DIFF
--- a/packages/custom-version-view/src/CustomVersionViewPlugin.ts
+++ b/packages/custom-version-view/src/CustomVersionViewPlugin.ts
@@ -3,11 +3,17 @@ import type { Config } from 'payload';
 export interface versionsPluginPConfig {
   excludedCollections?: string[];
   excludedGlobals?: string[];
+  updatedByField?: string;
+  createdByField?: string;
+  processField?: string;
 }
 
 const defaultConfig: Required<versionsPluginPConfig> = {
   excludedCollections: [],
   excludedGlobals: [],
+  updatedByField: 'updator',
+  createdByField: 'creator',
+  processField: 'process',
 };
 
 function ensurePath(obj: any, path: string[]): any {
@@ -34,6 +40,14 @@ const versionsPlugin =
           if (!currentCollection.admin?.components?.views?.edit?.versions?.Component) {
             versions.Component = { path: '@shefing/custom-version-view/index' } as any;
           }
+          currentCollection.custom = {
+            ...currentCollection.custom,
+            customVersionView: {
+              updatedByField: mergedConfig.updatedByField,
+              createdByField: mergedConfig.createdByField,
+              processField: mergedConfig.processField,
+            },
+          };
         });
     }
     if (globals !== undefined) {
@@ -51,6 +65,14 @@ const versionsPlugin =
             ]);
             versions.Component = { path: '@shefing/custom-version-view/index' } as any;
           }
+          currentGlobal.custom = {
+            ...currentGlobal.custom,
+            customVersionView: {
+              updatedByField: mergedConfig.updatedByField,
+              createdByField: mergedConfig.createdByField,
+              processField: mergedConfig.processField,
+            },
+          };
         });
     }
 

--- a/packages/custom-version-view/src/components/buildColumns.tsx
+++ b/packages/custom-version-view/src/components/buildColumns.tsx
@@ -35,6 +35,9 @@ export const buildVersionColumns = ({
                                       i18n: { t },
                                       isTrashed,
                                       latestDraftVersion,
+                                      updatedByField = 'updator',
+                                      createdByField = 'creator',
+                                      processField = 'process',
                                     }: {
   collectionConfig?: SanitizedCollectionConfig
   CreatedAtCellOverride?: React.ComponentType<CreatedAtCellProps>
@@ -45,6 +48,9 @@ export const buildVersionColumns = ({
   i18n: I18n
   isTrashed?: boolean
   latestDraftVersion?: TypeWithVersion<any>
+  updatedByField?: string
+  createdByField?: string
+  processField?: string
 }): Column[] => {
   const entityConfig = collectionConfig || globalConfig
 
@@ -90,27 +96,27 @@ export const buildVersionColumns = ({
   ];
 
   columns.splice(1, 0, {
-    accessor: 'updator',
+    accessor: updatedByField,
     active: true,
     field: {
       name: '',
       type: 'text',
     },
-    Heading: <SortColumn Label={'Updated by'} disable name='updator' />,
-    renderedCells: docs.map((doc:Updator, i) => {
-      return <IDCell id={doc.updator as string} key={i} />;
+    Heading: <SortColumn Label={'Updated by'} disable name={updatedByField} />,
+    renderedCells: docs.map((doc: any, i) => {
+      return <IDCell id={doc[updatedByField] as string} key={i} />;
     }),
   });
   columns.splice(1, 0, {
-    accessor: 'process',
+    accessor: processField,
     active: true,
     field: {
       name: '',
       type: 'text',
     },
-    Heading: <SortColumn Label={'Process'} disable name='process' />,
-    renderedCells: docs.map((doc:Updator, i) => {
-      return <IDCell id={doc.process as string} key={i} />;
+    Heading: <SortColumn Label={'Process'} disable name={processField} />,
+    renderedCells: docs.map((doc: any, i) => {
+      return <IDCell id={doc[processField] as string} key={i} />;
     }),
   });
   if (

--- a/packages/custom-version-view/src/index.tsx
+++ b/packages/custom-version-view/src/index.tsx
@@ -79,9 +79,17 @@ export default async function VersionsView(props: DocumentViewServerProps) {
   if (!versionsData) {
     return notFound()
   }
+  const customVersionViewConfig = (collectionConfig ?? globalConfig)?.custom?.customVersionView as
+    | { updatedByField?: string; createdByField?: string; processField?: string }
+    | undefined
+
+  const updatedByField = customVersionViewConfig?.updatedByField ?? 'updator'
+  const createdByField = customVersionViewConfig?.createdByField ?? 'creator'
+  const processField = customVersionViewConfig?.processField ?? 'process'
+
   versionsData.docs.forEach((doc) => {
-    if (doc.version.updator) doc.updator = doc.version.updator;
-    if (doc.version.process) doc.process = doc.version.process;
+    if (doc.version[updatedByField]) doc[updatedByField] = doc.version[updatedByField];
+    if (doc.version[processField]) doc[processField] = doc.version[processField];
   });
 
 
@@ -134,6 +142,9 @@ export default async function VersionsView(props: DocumentViewServerProps) {
     i18n,
     isTrashed,
     latestDraftVersion,
+    updatedByField,
+    createdByField,
+    processField,
   })
 
   const pluralLabel =

--- a/test-app/tests/e2e-plugins/custom-version-view.spec.ts
+++ b/test-app/tests/e2e-plugins/custom-version-view.spec.ts
@@ -86,4 +86,47 @@ test.describe('versionsPlugin (@shefing/custom-version-view)', () => {
     const relativeTime = page.getByText(/ago|just now|a few seconds/i).first()
     await expect(relativeTime).toBeVisible({ timeout: 10000 })
   })
+
+  test('versions list shows "Updated by" column header', async ({ page }) => {
+    await expect(page.locator('input[name="title"]')).toBeVisible({ timeout: 15000 })
+    const tab = versionsTab(page)
+    await tab.waitFor({ state: 'visible', timeout: 15000 })
+    await tab.click()
+    await page.waitForURL(/\/versions/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle', { timeout: 15000 })
+
+    await expect(page.getByText('Updated by').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('versions list shows "Process" column header', async ({ page }) => {
+    await expect(page.locator('input[name="title"]')).toBeVisible({ timeout: 15000 })
+    const tab = versionsTab(page)
+    await tab.waitFor({ state: 'visible', timeout: 15000 })
+    await tab.click()
+    await page.waitForURL(/\/versions/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle', { timeout: 15000 })
+
+    await expect(page.getByText('Process').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('updatedByField config defaults to "updator" field name', async ({ request }) => {
+    // Verify the plugin uses the default field name by checking the versions API response
+    const token = await getToken(request)
+    const suffix = randomSuffix()
+    const id = await createArticle(request, token, {
+      title: `Version Field Config Test ${suffix}`,
+      _status: 'draft',
+    })
+
+    const versionsRes = await request.get(`/api/articles/versions?where[parent][equals]=${id}`, {
+      headers: { Authorization: token },
+    })
+    expect(versionsRes.ok()).toBeTruthy()
+    const versionsBody = await versionsRes.json()
+    // The versions docs should exist
+    expect(versionsBody.docs).toBeDefined()
+    expect(versionsBody.docs.length).toBeGreaterThan(0)
+
+    await request.delete(`/api/articles/${id}`, { headers: { Authorization: token } })
+  })
 })


### PR DESCRIPTION
Closes #45

## Summary
Makes `updatedBy`, `createdBy`, and `process` field names configurable in the `@shefing/custom-version-view` plugin instead of being hardcoded.

## Changes
- **`CustomVersionViewPlugin.ts`**: Added `updatedByField`, `createdByField`, `processField` to `versionsPluginPConfig` interface (defaults: `'updator'`, `'creator'`, `'process'`). Plugin stores these in `collection.custom.customVersionView` / `global.custom.customVersionView`.
- **`index.tsx`**: Reads field config from `collectionConfig.custom.customVersionView`, falls back to defaults, passes them to `buildVersionColumns`.
- **`buildColumns.tsx`**: `buildVersionColumns` now accepts `updatedByField`, `createdByField`, `processField` params and uses them dynamically.
- **`custom-version-view.spec.ts`**: Added 3 new E2E tests verifying column headers and versions API response.

## Backward Compatibility
Fully backward-compatible — defaults preserve existing behavior.