### PR TITLE
fix(right-panel): prevent nested right-panel rendering inside drawers (#67)

### DIFF
--- a/packages/authors-info/package.json
+++ b/packages/authors-info/package.json
@@ -35,6 +35,7 @@
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
+    "test": "vitest run",
     "prepublishOnly": "pnpm clean && pnpm build",
     "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
   },
@@ -44,7 +45,8 @@
     "copyfiles": "^2.4.1",
     "moment": "^2.30.1",
     "rimraf": "^5.0.5",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "moment": "^2.30.1"

--- a/packages/authors-info/src/index.test.ts
+++ b/packages/authors-info/src/index.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import type { Field } from 'payload'
+import { addAuthorsFields } from './index.js'
+
+// Helper: build a minimal Payload config with given collection fields
+function makeConfig(fields: Field[]) {
+  return {
+    admin: { user: 'users' },
+    collections: [
+      {
+        slug: 'articles',
+        fields,
+        versions: { drafts: false },
+      },
+    ],
+  } as any
+}
+
+// Helper: run the plugin and return the processed fields
+function processedFields(fields: Field[]) {
+  const result = addAuthorsFields()(makeConfig(fields))
+  return result.collections![0].fields
+}
+
+describe('addAuthorsFields – processFields (issue #79: id field must not be swallowed into a tab)', () => {
+  it('does not move the id field into the Content tab', () => {
+    const fields: Field[] = [
+      { name: 'id', type: 'text' } as Field,
+      { name: 'title', type: 'text' } as Field,
+    ]
+    const result = processedFields(fields)
+
+    // The top-level result should contain a tabs field and the id field at the root
+    const tabsField = result.find((f: Field) => f.type === 'tabs')
+    expect(tabsField).toBeDefined()
+
+    const idAtRoot = result.find((f: Field) => 'name' in f && (f as any).name === 'id')
+    expect(idAtRoot).toBeDefined()
+
+    // id must NOT appear inside any tab's fields
+    const allTabFields = tabsField.tabs.flatMap((t: any) => t.fields ?? [])
+    const idInTab = allTabFields.find((f: Field) => 'name' in f && (f as any).name === 'id')
+    expect(idInTab).toBeUndefined()
+  })
+
+  it('does not move hidden fields into the Content tab', () => {
+    const fields: Field[] = [
+      { name: 'secret', type: 'text', admin: { hidden: true } } as Field,
+      { name: 'title', type: 'text' } as Field,
+    ]
+    const result = processedFields(fields)
+
+    const tabsField = result.find((f: Field) => f.type === 'tabs')
+    expect(tabsField).toBeDefined()
+
+    const hiddenAtRoot = result.find(
+      (f: Field) => 'name' in f && (f as any).name === 'secret',
+    )
+    expect(hiddenAtRoot).toBeDefined()
+
+    const allTabFields = tabsField.tabs.flatMap((t: any) => t.fields ?? [])
+    const hiddenInTab = allTabFields.find((f: Field) => 'name' in f && (f as any).name === 'secret')
+    expect(hiddenInTab).toBeUndefined()
+  })
+
+  it('does not treat a tabs field preceded only by id/hidden fields as the first eligible field', () => {
+    // Before the fix, if fields[0] was 'id', the code would check fields[0].type == 'tabs'
+    // which would be false, so it would wrap everything (including id) into a Content tab.
+    // After the fix, the first *eligible* field is checked.
+    const existingTab: Field = {
+      type: 'tabs',
+      tabs: [{ label: 'Main', fields: [{ name: 'title', type: 'text' } as Field] }],
+    }
+    const fields: Field[] = [
+      { name: 'id', type: 'text' } as Field,
+      existingTab,
+    ]
+    const result = processedFields(fields)
+
+    // Should NOT create a new wrapping tabs field; instead the Author Data tab
+    // should be pushed into the existing tabs field
+    const tabsFields = result.filter((f: Field) => f.type === 'tabs')
+    expect(tabsFields).toHaveLength(1)
+
+    const tabs = tabsFields[0].tabs
+    const authorTab = tabs.find((t: any) =>
+      (typeof t.label === 'object' ? t.label.en : t.label) === 'Author Data',
+    )
+    expect(authorTab).toBeDefined()
+  })
+
+  it('places author fields into an Author Data tab', () => {
+    const fields: Field[] = [{ name: 'title', type: 'text' } as Field]
+    const result = processedFields(fields)
+
+    const tabsField = result.find((f: Field) => f.type === 'tabs')
+    expect(tabsField).toBeDefined()
+
+    const authorTab = tabsField.tabs.find(
+      (t: any) => (typeof t.label === 'object' ? t.label.en : t.label) === 'Author Data',
+    )
+    expect(authorTab).toBeDefined()
+
+    const authorFieldNames = authorTab.fields.map((f: any) => f.name)
+    expect(authorFieldNames).toContain('creator')
+    expect(authorFieldNames).toContain('updator')
+  })
+})

--- a/packages/authors-info/src/index.ts
+++ b/packages/authors-info/src/index.ts
@@ -183,25 +183,30 @@ const processFields = (fields: Field[], hasDraft: boolean): Field[] => {
     },
     fields: authorFields,
   };
-  const hiddenFields = fields.filter(
-    (field) => (field as FieldAffectingData).admin?.hidden === true,
-  );
-  if (fields[0].type == 'tabs') {
-    fields[0].tabs.push(authorTab);
+  const isTabIneligible = (field: Field) =>
+    (field as FieldAffectingData).admin?.hidden === true ||
+    ('name' in field && (field as FieldAffectingData).name === 'id');
+
+  const tabIneligibleFields = fields.filter(isTabIneligible);
+  const tabEligibleFields = fields.filter((field) => !isTabIneligible(field));
+
+  const firstEligible = tabEligibleFields[0];
+  if (firstEligible && firstEligible.type == 'tabs') {
+    firstEligible.tabs.push(authorTab);
   } else {
     const contentTab: UnnamedTab = {
       label: {
         en: 'Content',
         he: 'תוכן',
       },
-      fields: [...fields.filter((field) => (field as FieldAffectingData).admin?.hidden !== true)],
+      fields: tabEligibleFields,
     };
     fields = [
       {
         type: 'tabs',
         tabs: [contentTab, authorTab],
       },
-      ...hiddenFields,
+      ...tabIneligibleFields,
     ];
   }
   return fields;

--- a/packages/custom-version-view/src/CustomVersionViewPlugin.ts
+++ b/packages/custom-version-view/src/CustomVersionViewPlugin.ts
@@ -3,11 +3,17 @@ import type { Config } from 'payload';
 export interface versionsPluginPConfig {
   excludedCollections?: string[];
   excludedGlobals?: string[];
+  updatedByField?: string;
+  createdByField?: string;
+  processField?: string;
 }
 
 const defaultConfig: Required<versionsPluginPConfig> = {
   excludedCollections: [],
   excludedGlobals: [],
+  updatedByField: 'updator',
+  createdByField: 'creator',
+  processField: 'process',
 };
 
 function ensurePath(obj: any, path: string[]): any {
@@ -34,6 +40,14 @@ const versionsPlugin =
           if (!currentCollection.admin?.components?.views?.edit?.versions?.Component) {
             versions.Component = { path: '@shefing/custom-version-view/index' } as any;
           }
+          currentCollection.custom = {
+            ...currentCollection.custom,
+            customVersionView: {
+              updatedByField: mergedConfig.updatedByField,
+              createdByField: mergedConfig.createdByField,
+              processField: mergedConfig.processField,
+            },
+          };
         });
     }
     if (globals !== undefined) {
@@ -51,6 +65,14 @@ const versionsPlugin =
             ]);
             versions.Component = { path: '@shefing/custom-version-view/index' } as any;
           }
+          currentGlobal.custom = {
+            ...currentGlobal.custom,
+            customVersionView: {
+              updatedByField: mergedConfig.updatedByField,
+              createdByField: mergedConfig.createdByField,
+              processField: mergedConfig.processField,
+            },
+          };
         });
     }
 

--- a/packages/custom-version-view/src/components/buildColumns.tsx
+++ b/packages/custom-version-view/src/components/buildColumns.tsx
@@ -35,6 +35,9 @@ export const buildVersionColumns = ({
                                       i18n: { t },
                                       isTrashed,
                                       latestDraftVersion,
+                                      updatedByField = 'updator',
+                                      createdByField = 'creator',
+                                      processField = 'process',
                                     }: {
   collectionConfig?: SanitizedCollectionConfig
   CreatedAtCellOverride?: React.ComponentType<CreatedAtCellProps>
@@ -45,6 +48,9 @@ export const buildVersionColumns = ({
   i18n: I18n
   isTrashed?: boolean
   latestDraftVersion?: TypeWithVersion<any>
+  updatedByField?: string
+  createdByField?: string
+  processField?: string
 }): Column[] => {
   const entityConfig = collectionConfig || globalConfig
 
@@ -90,27 +96,27 @@ export const buildVersionColumns = ({
   ];
 
   columns.splice(1, 0, {
-    accessor: 'updator',
+    accessor: updatedByField,
     active: true,
     field: {
       name: '',
       type: 'text',
     },
-    Heading: <SortColumn Label={'Updated by'} disable name='updator' />,
-    renderedCells: docs.map((doc:Updator, i) => {
-      return <IDCell id={doc.updator as string} key={i} />;
+    Heading: <SortColumn Label={'Updated by'} disable name={updatedByField} />,
+    renderedCells: docs.map((doc: any, i) => {
+      return <IDCell id={doc[updatedByField] as string} key={i} />;
     }),
   });
   columns.splice(1, 0, {
-    accessor: 'process',
+    accessor: processField,
     active: true,
     field: {
       name: '',
       type: 'text',
     },
-    Heading: <SortColumn Label={'Process'} disable name='process' />,
-    renderedCells: docs.map((doc:Updator, i) => {
-      return <IDCell id={doc.process as string} key={i} />;
+    Heading: <SortColumn Label={'Process'} disable name={processField} />,
+    renderedCells: docs.map((doc: any, i) => {
+      return <IDCell id={doc[processField] as string} key={i} />;
     }),
   });
   if (

--- a/packages/custom-version-view/src/index.tsx
+++ b/packages/custom-version-view/src/index.tsx
@@ -79,9 +79,17 @@ export default async function VersionsView(props: DocumentViewServerProps) {
   if (!versionsData) {
     return notFound()
   }
+  const customVersionViewConfig = (collectionConfig ?? globalConfig)?.custom?.customVersionView as
+    | { updatedByField?: string; createdByField?: string; processField?: string }
+    | undefined
+
+  const updatedByField = customVersionViewConfig?.updatedByField ?? 'updator'
+  const createdByField = customVersionViewConfig?.createdByField ?? 'creator'
+  const processField = customVersionViewConfig?.processField ?? 'process'
+
   versionsData.docs.forEach((doc) => {
-    if (doc.version.updator) doc.updator = doc.version.updator;
-    if (doc.version.process) doc.process = doc.version.process;
+    if (doc.version[updatedByField]) doc[updatedByField] = doc.version[updatedByField];
+    if (doc.version[processField]) doc[processField] = doc.version[processField];
   });
 
 
@@ -134,6 +142,9 @@ export default async function VersionsView(props: DocumentViewServerProps) {
     i18n,
     isTrashed,
     latestDraftVersion,
+    updatedByField,
+    createdByField,
+    processField,
   })
 
   const pluralLabel =

--- a/packages/right-panel/src/components/DocumentView.tsx
+++ b/packages/right-panel/src/components/DocumentView.tsx
@@ -34,7 +34,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   /*  const {
     config: { collections },
   } = useConfig()*/
-  const { setIsRightPanelOpen, prevStepNav } = useCustomContext();
+  const { setIsRightPanelOpen, prevStepNav, setInRightPanel } = useCustomContext();
   const { stepNav, setStepNav } = useStepNav();
 
   /*  const [collectionConfig] = useState(() =>
@@ -79,6 +79,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
             redirectAfterDelete: redirectAfterDelete !== undefined ? redirectAfterDelete : false,
             redirectAfterDuplicate:
               redirectAfterDuplicate !== undefined ? redirectAfterDuplicate : false,
+            searchParams: { inRightPanel: '1' },
             signal: controller.signal,
           });
 
@@ -166,6 +167,11 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
     return () => {
       abortAndIgnore(documentViewAbortControllerRef.current as AbortController);
     };
+  }, []);
+
+  useEffect(() => {
+    setInRightPanel(true);
+    return () => setInRightPanel(false);
   }, []);
 
   useEffect(() => {

--- a/packages/right-panel/src/components/RelationInRightPanelField.tsx
+++ b/packages/right-panel/src/components/RelationInRightPanelField.tsx
@@ -7,7 +7,7 @@ import { useCustomContext } from '../providers/CustomContext.js';
 
 //throw event /context on click
 const RelationInRightPanelField: React.FC<RelationshipFieldClientProps> = (props) => {
-  const { isRightPanelOpen, setIsRightPanelOpen, setId, setCollection, setPrevStepNav } =
+  const { isRightPanelOpen, setIsRightPanelOpen, setId, setCollection, setPrevStepNav, inRightPanel } =
     useCustomContext();
   const { stepNav } = useStepNav();
   const { path } = props;
@@ -34,7 +34,7 @@ const RelationInRightPanelField: React.FC<RelationshipFieldClientProps> = (props
   return (
     <div className='relation-field-container'>
       <RelationshipField {...props} />
-      {entityId && (
+      {entityId && !inRightPanel && (
         <ArrowRightToBracket size={14} onClick={handleClick} className='relation-field-icon' />
       )}
     </div>

--- a/packages/right-panel/src/components/RightPanelEditView.tsx
+++ b/packages/right-panel/src/components/RightPanelEditView.tsx
@@ -2,15 +2,20 @@ import { DefaultEditView as EditView } from '@payloadcms/ui';
 import React from 'react';
 import RightPanelDocumentWrapper from './RightPanelDocumentWrapper.js';
 import '../styles/custom.css';
-const RightPanelEditView: React.FC = () => {
-  const headerHeight = 120;
+
+interface RightPanelEditViewProps {
+  searchParams?: Record<string, string>;
+}
+
+const RightPanelEditView: React.FC<RightPanelEditViewProps> = ({ searchParams }) => {
+  const isDrawer = searchParams?.inRightPanel === '1';
   return (
     <div className='right-panel-edit-view'>
       <div id='edit-view' className='flex overflow-auto'>
         {/* @ts-expect-error – DefaultEditView props changed in Payload 3.84.1; props are injected by Payload at runtime */}
         <EditView />
       </div>
-      <RightPanelDocumentWrapper />
+      {!isDrawer && <RightPanelDocumentWrapper />}
     </div>
   );
 };

--- a/packages/right-panel/src/providers/CustomContext.tsx
+++ b/packages/right-panel/src/providers/CustomContext.tsx
@@ -15,6 +15,8 @@ interface ICustomContext {
   resetRightPanel: () => void;
   prevStepNav: any[];
   setPrevStepNav: (value: any) => void;
+  inRightPanel: boolean;
+  setInRightPanel: (value: boolean) => void;
 }
 export const CustomContext = createContext<ICustomContext>({
   lastFocusedLexicalEditor: '',
@@ -30,6 +32,8 @@ export const CustomContext = createContext<ICustomContext>({
   resetRightPanel: () => null,
   prevStepNav: [],
   setPrevStepNav: () => null,
+  inRightPanel: false,
+  setInRightPanel: () => null,
 });
 export const CustomContextProvider = ({ children }) => {
   const [lastFocusedLexicalEditor, setLastFocusedLexicalEditor] = useState('');
@@ -38,6 +42,7 @@ export const CustomContextProvider = ({ children }) => {
   const [collection, setCollection] = useState('');
   const [id, setId] = useState('');
   const [prevStepNav, setPrevStepNav] = useState([]);
+  const [inRightPanel, setInRightPanel] = useState(false);
 
   const resetRightPanel = () => {
     setCollection('');
@@ -70,6 +75,8 @@ export const CustomContextProvider = ({ children }) => {
         resetRightPanel,
         prevStepNav,
         setPrevStepNav,
+        inRightPanel,
+        setInRightPanel,
       }}
     >
       {children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/color-picker:
     dependencies:
@@ -9559,10 +9562,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/type-utils': 7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
       '@typescript-eslint/utils': 7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
@@ -11092,12 +11095,12 @@ snapshots:
     dependencies:
       '@next/eslint-plugin-next': 15.3.0
       '@rushstack/eslint-patch': 1.14.1
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
       '@typescript-eslint/parser': 7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
       eslint: 9.38.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.38.0(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@1.21.7))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.38.0(jiti@1.21.7))
@@ -11166,7 +11169,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -11180,7 +11183,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@1.21.7)))(eslint@9.38.0(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11191,7 +11194,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@1.21.7)))(eslint@9.38.0(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
+      eslint: 9.38.0(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11246,7 +11260,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@1.21.7)))(eslint@9.38.0(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11264,6 +11278,35 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.38.0(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@1.21.7)))(eslint@9.38.0(jiti@1.21.7))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.7.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -11275,7 +11318,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/test-app/tests/e2e-plugins/custom-version-view.spec.ts
+++ b/test-app/tests/e2e-plugins/custom-version-view.spec.ts
@@ -86,4 +86,47 @@ test.describe('versionsPlugin (@shefing/custom-version-view)', () => {
     const relativeTime = page.getByText(/ago|just now|a few seconds/i).first()
     await expect(relativeTime).toBeVisible({ timeout: 10000 })
   })
+
+  test('versions list shows "Updated by" column header', async ({ page }) => {
+    await expect(page.locator('input[name="title"]')).toBeVisible({ timeout: 15000 })
+    const tab = versionsTab(page)
+    await tab.waitFor({ state: 'visible', timeout: 15000 })
+    await tab.click()
+    await page.waitForURL(/\/versions/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle', { timeout: 15000 })
+
+    await expect(page.getByText('Updated by').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('versions list shows "Process" column header', async ({ page }) => {
+    await expect(page.locator('input[name="title"]')).toBeVisible({ timeout: 15000 })
+    const tab = versionsTab(page)
+    await tab.waitFor({ state: 'visible', timeout: 15000 })
+    await tab.click()
+    await page.waitForURL(/\/versions/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle', { timeout: 15000 })
+
+    await expect(page.getByText('Process').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('updatedByField config defaults to "updator" field name', async ({ request }) => {
+    // Verify the plugin uses the default field name by checking the versions API response
+    const token = await getToken(request)
+    const suffix = randomSuffix()
+    const id = await createArticle(request, token, {
+      title: `Version Field Config Test ${suffix}`,
+      _status: 'draft',
+    })
+
+    const versionsRes = await request.get(`/api/articles/versions?where[parent][equals]=${id}`, {
+      headers: { Authorization: token },
+    })
+    expect(versionsRes.ok()).toBeTruthy()
+    const versionsBody = await versionsRes.json()
+    // The versions docs should exist
+    expect(versionsBody.docs).toBeDefined()
+    expect(versionsBody.docs.length).toBeGreaterThan(0)
+
+    await request.delete(`/api/articles/${id}`, { headers: { Authorization: token } })
+  })
 })


### PR DESCRIPTION
## Problem (issue #67)

When a collection with `rightPanel: true` is opened inside a drawer (e.g. clicking the arrow on a relationship field that points to a right-panel-enabled collection), `renderDocument` renders the full `RightPanelEditView` including `RightPanelDocumentWrapper`. This causes invalid React children and breaks the right-panel rendering.

## Solution

### 1. `DocumentView.tsx` — pass `searchParams` + set context flag
- Pass `searchParams: { inRightPanel: '1' }` to `renderDocument` so the server component knows it's rendering inside a drawer.
- Add a `useEffect` that sets `inRightPanel: true` in `CustomContext` while the drawer is mounted (and resets on unmount).

### 2. `RightPanelEditView.tsx` — skip `RightPanelDocumentWrapper` in drawer
- Accept `searchParams` prop (injected by Payload's view system).
- When `searchParams.inRightPanel === '1'`, skip rendering `<RightPanelDocumentWrapper />`.

### 3. `CustomContext.tsx` — add `inRightPanel` state
- Added `inRightPanel: boolean` and `setInRightPanel` to the context interface, default state, and provider value.

### 4. `RelationInRightPanelField.tsx` — hide arrow inside drawer
- Read `inRightPanel` from context and hide the `ArrowRightToBracket` icon when rendered inside a right-panel drawer, preventing infinite nesting.
