### PR TITLE
feat: add unit tests across all plugins (issue #90)

### DIFF
--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -28,10 +28,12 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/authorization/src/access/general.test.ts
+++ b/packages/authorization/src/access/general.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { canUserAccessAction } from './general.js'
+
+const pluginConfig: any = {
+  rolesCollection: 'roles',
+  permissionsField: 'permissions',
+}
+
+function makePayload(docs: any[]) {
+  return {
+    find: vi.fn().mockResolvedValue({ docs }),
+  } as any
+}
+
+describe('canUserAccessAction', () => {
+  it('returns false when user is null', async () => {
+    const result = await canUserAccessAction(null, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when user is undefined', async () => {
+    const result = await canUserAccessAction(undefined, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns true when user isAdmin', async () => {
+    const user: any = { isAdmin: true }
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(true)
+  })
+
+  it('returns false when user has no userRoles', async () => {
+    const user: any = { isAdmin: false, userRoles: [] }
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when roles collection returns no docs', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns true when role grants read permission on the slug', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: 'read' }],
+      },
+    ]
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    expect(result).toBe(true)
+  })
+
+  it('returns false when role grants permission on a different slug', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['pages'], type: 'read' }],
+      },
+    ]
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('grants read and write when role has write permission (hierarchy)', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: 'write' }],
+      },
+    ]
+    const readResult = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    const writeResult = await canUserAccessAction(user, 'articles', 'write', makePayload(roles), pluginConfig)
+    expect(readResult).toBe(true)
+    expect(writeResult).toBe(true)
+  })
+
+  it('grants read, write and publish when role has publish permission (hierarchy)', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: 'publish' }],
+      },
+    ]
+    const readResult = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    const writeResult = await canUserAccessAction(user, 'articles', 'write', makePayload(roles), pluginConfig)
+    const publishResult = await canUserAccessAction(user, 'articles', 'publish', makePayload(roles), pluginConfig)
+    expect(readResult).toBe(true)
+    expect(writeResult).toBe(true)
+    expect(publishResult).toBe(true)
+  })
+
+  it('propagates errors thrown by payload.find', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const payload: any = { find: vi.fn().mockRejectedValue(new Error('DB error')) }
+    await expect(
+      canUserAccessAction(user, 'articles', 'read', payload, pluginConfig),
+    ).rejects.toThrow('DB error')
+  })
+})

--- a/packages/authorization/src/fields/populateOptions.test.ts
+++ b/packages/authorization/src/fields/populateOptions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { populateOptions } from './populateOptions.js'
+
+describe('populateOptions', () => {
+  const entities = [
+    { label: 'Articles', value: 'articles' },
+    { label: 'Pages', value: 'pages' },
+  ]
+
+  it('sets options on a flat entity select field', () => {
+    const fields: any[] = [{ name: 'entity', type: 'select', options: [] }]
+    populateOptions(fields, entities)
+    expect(fields[0].options).toEqual(entities)
+  })
+
+  it('sets options on a nested entity field inside a group', () => {
+    const fields: any[] = [
+      {
+        name: 'permissions',
+        type: 'array',
+        fields: [{ name: 'entity', type: 'select', options: [] }],
+      },
+    ]
+    populateOptions(fields, entities)
+    expect(fields[0].fields[0].options).toEqual(entities)
+  })
+
+  it('sets options on entity fields inside tabs', () => {
+    const fields: any[] = [
+      {
+        type: 'tabs',
+        tabs: [
+          {
+            fields: [{ name: 'entity', type: 'select', options: [] }],
+          },
+        ],
+      },
+    ]
+    populateOptions(fields, entities)
+    expect(fields[0].tabs[0].fields[0].options).toEqual(entities)
+  })
+
+  it('does not modify fields that are not named entity', () => {
+    const fields: any[] = [{ name: 'title', type: 'text' }]
+    populateOptions(fields, entities)
+    expect((fields[0] as any).options).toBeUndefined()
+  })
+
+  it('handles empty fields array without error', () => {
+    expect(() => populateOptions([], entities)).not.toThrow()
+  })
+})

--- a/packages/authorization/src/utilities/ensurePath.test.ts
+++ b/packages/authorization/src/utilities/ensurePath.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { ensurePath } from './ensurePath.js'
+
+describe('ensurePath', () => {
+  it('creates nested keys that do not exist', () => {
+    const obj: any = {}
+    const result = ensurePath(obj, ['a', 'b', 'c'])
+    expect(obj.a.b.c).toEqual({})
+    expect(result).toBe(obj.a.b.c)
+  })
+
+  it('does not overwrite existing nested objects', () => {
+    const obj: any = { a: { b: { existing: true } } }
+    ensurePath(obj, ['a', 'b', 'c'])
+    expect(obj.a.b.existing).toBe(true)
+    expect(obj.a.b.c).toEqual({})
+  })
+
+  it('returns the leaf object', () => {
+    const obj: any = {}
+    const leaf = ensurePath(obj, ['x', 'y'])
+    leaf.value = 42
+    expect(obj.x.y.value).toBe(42)
+  })
+
+  it('handles a single-element path', () => {
+    const obj: any = {}
+    ensurePath(obj, ['key'])
+    expect(obj.key).toEqual({})
+  })
+
+  it('handles an empty path by returning the root object', () => {
+    const obj: any = { root: true }
+    const result = ensurePath(obj, [])
+    expect(result).toBe(obj)
+  })
+})

--- a/packages/cross-collection/package.json
+++ b/packages/cross-collection/package.json
@@ -32,10 +32,12 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cross-collection/src/index.test.ts
+++ b/packages/cross-collection/src/index.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import CrossCollectionConfig, { ensurePath } from './index.js'
+
+describe('ensurePath', () => {
+  it('creates nested keys that do not exist', () => {
+    const obj: any = {}
+    const result = ensurePath(obj, ['a', 'b'])
+    expect(obj.a.b).toEqual({})
+    expect(result).toBe(obj.a.b)
+  })
+
+  it('does not overwrite existing values', () => {
+    const obj: any = { a: { existing: true } }
+    ensurePath(obj, ['a', 'b'])
+    expect(obj.a.existing).toBe(true)
+    expect(obj.a.b).toEqual({})
+  })
+
+  it('returns the leaf object so callers can assign to it', () => {
+    const obj: any = {}
+    const leaf = ensurePath(obj, ['x', 'y'])
+    leaf.Component = 'MyComponent'
+    expect(obj.x.y.Component).toBe('MyComponent')
+  })
+})
+
+describe('CrossCollectionConfig', () => {
+  it('returns config unchanged when no collections or globals', () => {
+    const config: any = { collections: [], globals: [] }
+    const result = CrossCollectionConfig()(config)
+    expect(result.collections).toEqual([])
+    expect(result.globals).toEqual([])
+  })
+
+  it('applies customOverrides to all collections by default', () => {
+    const MyComponent = () => null
+    const config: any = {
+      collections: [{ slug: 'articles', fields: [] }, { slug: 'pages', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.collections[0].admin.components.edit.Component).toBe(MyComponent)
+    expect(result.collections[1].admin.components.edit.Component).toBe(MyComponent)
+  })
+
+  it('excludes specified collections from overrides', () => {
+    const MyComponent = () => null
+    const config: any = {
+      collections: [{ slug: 'articles', fields: [] }, { slug: 'pages', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      excludedCollections: ['pages'],
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.collections[0].admin.components.edit.Component).toBe(MyComponent)
+    expect(result.collections[1].admin).toBeUndefined()
+  })
+
+  it('applies customOverrides to globals', () => {
+    const MyComponent = () => null
+    const config: any = {
+      globals: [{ slug: 'settings', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.globals[0].admin.components.edit.Component).toBe(MyComponent)
+  })
+
+  it('excludes specified globals from overrides', () => {
+    const MyComponent = () => null
+    const config: any = {
+      globals: [{ slug: 'settings', fields: [] }, { slug: 'nav', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      excludedGlobals: ['nav'],
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.globals[0].admin.components.edit.Component).toBe(MyComponent)
+    expect(result.globals[1].admin).toBeUndefined()
+  })
+
+  it('handles missing collections gracefully', () => {
+    const config: any = { globals: [] }
+    expect(() => CrossCollectionConfig()(config)).not.toThrow()
+  })
+
+  it('handles missing globals gracefully', () => {
+    const config: any = { collections: [] }
+    expect(() => CrossCollectionConfig()(config)).not.toThrow()
+  })
+
+  it('uses empty defaults when no pluginConfig is provided', () => {
+    const config: any = { collections: [{ slug: 'articles', fields: [] }] }
+    const result = CrossCollectionConfig()(config)
+    expect(result.collections[0].admin).toBeUndefined()
+  })
+})

--- a/packages/custom-version-view/package.json
+++ b/packages/custom-version-view/package.json
@@ -31,13 +31,15 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
     "mongodb": "^6.0.0",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "moment": "^2.30.1"

--- a/packages/custom-version-view/src/getLatestVersion.test.ts
+++ b/packages/custom-version-view/src/getLatestVersion.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getLatestVersion } from './getLatestVersion.js'
+
+function makePayload({
+  findVersionsDocs = [],
+  findGlobalVersionsDocs = [],
+}: {
+  findVersionsDocs?: any[]
+  findGlobalVersionsDocs?: any[]
+} = {}) {
+  return {
+    findVersions: vi.fn().mockResolvedValue({ docs: findVersionsDocs }),
+    findGlobalVersions: vi.fn().mockResolvedValue({ docs: findGlobalVersionsDocs }),
+  } as any
+}
+
+describe('getLatestVersion', () => {
+  it('returns null when no versions found for a collection', async () => {
+    const payload = makePayload()
+    const result = await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '123',
+      payload,
+      status: 'published',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns id and updatedAt for the latest collection version', async () => {
+    const payload = makePayload({
+      findVersionsDocs: [{ id: 'v1', updatedAt: '2024-01-01T00:00:00.000Z' }],
+    })
+    const result = await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '123',
+      payload,
+      status: 'published',
+    })
+    expect(result).toEqual({ id: 'v1', updatedAt: '2024-01-01T00:00:00.000Z' })
+  })
+
+  it('calls findVersions with correct where clause for collection', async () => {
+    const payload = makePayload({
+      findVersionsDocs: [{ id: 'v1', updatedAt: '2024-01-01T00:00:00.000Z' }],
+    })
+    await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '42',
+      payload,
+      status: 'draft',
+    })
+    expect(payload.findVersions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'articles',
+        where: expect.objectContaining({
+          and: expect.arrayContaining([
+            { 'version._status': { equals: 'draft' } },
+            { parent: { equals: '42' } },
+          ]),
+        }),
+      }),
+    )
+  })
+
+  it('calls findGlobalVersions for global type', async () => {
+    const payload = makePayload({
+      findGlobalVersionsDocs: [{ id: 'gv1', updatedAt: '2024-06-01T00:00:00.000Z' }],
+    })
+    const result = await getLatestVersion({
+      slug: 'settings',
+      type: 'global',
+      payload,
+      status: 'published',
+    })
+    expect(payload.findGlobalVersions).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'settings' }),
+    )
+    expect(result).toEqual({ id: 'gv1', updatedAt: '2024-06-01T00:00:00.000Z' })
+  })
+
+  it('returns null when no global versions found', async () => {
+    const payload = makePayload()
+    const result = await getLatestVersion({
+      slug: 'settings',
+      type: 'global',
+      payload,
+      status: 'published',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('does not add parent filter when parentID is not provided', async () => {
+    const payload = makePayload()
+    await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      payload,
+      status: 'published',
+    })
+    const callArg = payload.findVersions.mock.calls[0][0]
+    const hasParentFilter = callArg.where.and.some((c: any) => 'parent' in c)
+    expect(hasParentFilter).toBe(false)
+  })
+
+  it('returns null and does not throw on payload error', async () => {
+    const payload: any = {
+      findVersions: vi.fn().mockRejectedValue(new Error('DB error')),
+      findGlobalVersions: vi.fn(),
+    }
+    const result = await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '1',
+      payload,
+      status: 'published',
+    })
+    expect(result).toBeNull()
+  })
+})

--- a/packages/icon-select/package.json
+++ b/packages/icon-select/package.json
@@ -32,13 +32,15 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
     "tailwindcss": "^3.4.14",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.2",

--- a/packages/icon-select/src/lib/utils.test.ts
+++ b/packages/icon-select/src/lib/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils.js'
+
+describe('cn', () => {
+  it('returns a single class name unchanged', () => {
+    expect(cn('foo')).toBe('foo')
+  })
+
+  it('merges multiple class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles conditional classes (falsy values are ignored)', () => {
+    expect(cn('foo', false && 'bar', undefined, null, 'baz')).toBe('foo baz')
+  })
+
+  it('deduplicates conflicting tailwind classes (last wins)', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('merges tailwind utility conflicts correctly', () => {
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500')
+  })
+
+  it('returns empty string when no arguments provided', () => {
+    expect(cn()).toBe('')
+  })
+
+  it('handles array-style clsx inputs', () => {
+    expect(cn(['foo', 'bar'])).toBe('foo bar')
+  })
+})

--- a/packages/reset-list-view/src/index.test.ts
+++ b/packages/reset-list-view/src/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { CollectionResetPreferencesPlugin } from './index.js'
+
+const RESET_BUTTON_PATH = '@shefing/reset-list-view/ResetListViewButton#ResetListViewButton'
+
+function makeConfig(collections: any[] = [], extra: any = {}) {
+  return { collections, ...extra } as any
+}
+
+describe('CollectionResetPreferencesPlugin', () => {
+  it('returns config unchanged when disabled', () => {
+    const config = makeConfig([{ slug: 'articles', fields: [] }])
+    const result = CollectionResetPreferencesPlugin({ disabled: true })(config)
+    expect(result).toBe(config)
+  })
+
+  it('initializes collections array when missing', () => {
+    const config: any = {}
+    const result = CollectionResetPreferencesPlugin({})(config)
+    expect(Array.isArray(result.collections)).toBe(true)
+  })
+
+  it('adds reset button to all collections by default', () => {
+    const config = makeConfig([
+      { slug: 'articles', fields: [] },
+      { slug: 'pages', fields: [] },
+    ])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    for (const col of result.collections) {
+      const items = col.admin.components.listMenuItems
+      expect(items.some((i: any) => i.path === RESET_BUTTON_PATH)).toBe(true)
+    }
+  })
+
+  it('adds reset button only to includedCollections', () => {
+    const config = makeConfig([
+      { slug: 'articles', fields: [] },
+      { slug: 'pages', fields: [] },
+    ])
+    const result = CollectionResetPreferencesPlugin({ includedCollections: ['articles'] })(config)
+    const articles = result.collections.find((c: any) => c.slug === 'articles')
+    const pages = result.collections.find((c: any) => c.slug === 'pages')
+    expect(articles.admin.components.listMenuItems.some((i: any) => i.path === RESET_BUTTON_PATH)).toBe(true)
+    expect(pages.admin).toBeUndefined()
+  })
+
+  it('skips excludedCollections', () => {
+    const config = makeConfig([
+      { slug: 'articles', fields: [] },
+      { slug: 'pages', fields: [] },
+    ])
+    const result = CollectionResetPreferencesPlugin({ excludedCollections: ['pages'] })(config)
+    const articles = result.collections.find((c: any) => c.slug === 'articles')
+    const pages = result.collections.find((c: any) => c.slug === 'pages')
+    expect(articles.admin.components.listMenuItems.some((i: any) => i.path === RESET_BUTTON_PATH)).toBe(true)
+    expect(pages.admin).toBeUndefined()
+  })
+
+  it('passes the correct slug as clientProps', () => {
+    const config = makeConfig([{ slug: 'articles', fields: [] }])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    const items = result.collections[0].admin.components.listMenuItems
+    const btn = items.find((i: any) => i.path === RESET_BUTTON_PATH)
+    expect(btn.clientProps.slug).toBe('articles')
+  })
+
+  it('appends to existing listMenuItems array', () => {
+    const existingItem = { path: 'some/other/component' }
+    const config = makeConfig([
+      {
+        slug: 'articles',
+        fields: [],
+        admin: { components: { listMenuItems: [existingItem] } },
+      },
+    ])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    const items = result.collections[0].admin.components.listMenuItems
+    expect(items).toHaveLength(2)
+    expect(items[0]).toBe(existingItem)
+    expect(items[1].path).toBe(RESET_BUTTON_PATH)
+  })
+
+  it('converts non-array listMenuItems to array before appending', () => {
+    const existingItem = { path: 'some/other/component' }
+    const config = makeConfig([
+      {
+        slug: 'articles',
+        fields: [],
+        admin: { components: { listMenuItems: existingItem } },
+      },
+    ])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    const items = result.collections[0].admin.components.listMenuItems
+    expect(Array.isArray(items)).toBe(true)
+    expect(items).toHaveLength(2)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/authors-info:
     dependencies:
@@ -266,6 +269,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/custom-version-view:
     dependencies:
@@ -285,6 +291,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/field-type-components-override:
     devDependencies:
@@ -346,6 +355,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/quickfilter:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #90

Adds unit tests across all `payload-tools` plugins, following the pattern established by `getLabelString.test.ts` in `color-picker`.

## Changes

### `authorization` (20 tests)
- `ensurePath.test.ts` — nested key creation, no-overwrite, leaf return, edge cases
- `populateOptions.test.ts` — flat fields, nested arrays, tabs, non-entity fields
- `general.test.ts` — null/undefined user, admin bypass, role hierarchy (read/write/publish), error propagation

### `cross-collection` (11 tests)
- `index.test.ts` — `ensurePath` utility + `CrossCollectionConfig` overrides, exclusions, globals, missing collections/globals

### `custom-version-view` (7 tests)
- `getLatestVersion.test.ts` — collection/global version fetching, where-clause construction, missing parentID, error handling

### `icon-select` (7 tests)
- `utils.test.ts` — `cn` utility (clsx + tailwind-merge deduplication, conditionals, empty input)

### `reset-list-view` (8 tests)
- `index.test.ts` — disabled flag, includedCollections, excludedCollections, clientProps, array/non-array listMenuItems merging

## Verification

All **63 tests pass** across 7 packages:
| Package | Tests |
|---|---|
| authorization | 20 ✅ |
| cross-collection | 11 ✅ |
| custom-version-view | 7 ✅ |
| icon-select | 7 ✅ |
| reset-list-view | 8 ✅ |
| color-picker | 6 ✅ (existing) |
| authors-info | 4 ✅ (existing) |