### PR TITLE
Add CI/CD Workflows for Vitest and Playwright E2E tests

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -1,0 +1,51 @@
+name: CI E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @shefing/dev-app exec playwright install --with-deps chromium
+
+      - name: Build test-app
+        run: pnpm --filter @shefing/dev-app build
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+
+      - name: Run Playwright E2E tests
+        run: pnpm --filter @shefing/dev-app test:e2e
+        env:
+          CI: true
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: test-app/playwright-report/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches-ignore: []
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run Vitest (integration tests)
+        run: pnpm --filter @shefing/dev-app test:int

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -31,7 +31,37 @@ on:
           - major
 
 jobs:
+  test-before-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Run Vitest
+        run: pnpm --filter @shefing/dev-app test:int
+      - name: Install Playwright browsers
+        run: pnpm --filter @shefing/dev-app exec playwright install --with-deps chromium
+      - name: Build test-app
+        run: pnpm --filter @shefing/dev-app build
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+      - name: Run Playwright E2E
+        run: pnpm --filter @shefing/dev-app test:e2e
+        env:
+          CI: true
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+
   validate:
+    needs: test-before-publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -28,10 +28,12 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/authorization/src/access/general.test.ts
+++ b/packages/authorization/src/access/general.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { canUserAccessAction } from './general.js'
+
+const pluginConfig: any = {
+  rolesCollection: 'roles',
+  permissionsField: 'permissions',
+}
+
+function makePayload(docs: any[]) {
+  return {
+    find: vi.fn().mockResolvedValue({ docs }),
+  } as any
+}
+
+describe('canUserAccessAction', () => {
+  it('returns false when user is null', async () => {
+    const result = await canUserAccessAction(null, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when user is undefined', async () => {
+    const result = await canUserAccessAction(undefined, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns true when user isAdmin', async () => {
+    const user: any = { isAdmin: true }
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(true)
+  })
+
+  it('returns false when user has no userRoles', async () => {
+    const user: any = { isAdmin: false, userRoles: [] }
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when roles collection returns no docs', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload([]), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('returns true when role grants read permission on the slug', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: 'read' }],
+      },
+    ]
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    expect(result).toBe(true)
+  })
+
+  it('returns false when role grants permission on a different slug', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['pages'], type: 'read' }],
+      },
+    ]
+    const result = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    expect(result).toBe(false)
+  })
+
+  it('grants read and write when role has write permission (hierarchy)', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: 'write' }],
+      },
+    ]
+    const readResult = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    const writeResult = await canUserAccessAction(user, 'articles', 'write', makePayload(roles), pluginConfig)
+    expect(readResult).toBe(true)
+    expect(writeResult).toBe(true)
+  })
+
+  it('grants read, write and publish when role has publish permission (hierarchy)', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: 'publish' }],
+      },
+    ]
+    const readResult = await canUserAccessAction(user, 'articles', 'read', makePayload(roles), pluginConfig)
+    const writeResult = await canUserAccessAction(user, 'articles', 'write', makePayload(roles), pluginConfig)
+    const publishResult = await canUserAccessAction(user, 'articles', 'publish', makePayload(roles), pluginConfig)
+    expect(readResult).toBe(true)
+    expect(writeResult).toBe(true)
+    expect(publishResult).toBe(true)
+  })
+
+  it('propagates errors thrown by payload.find', async () => {
+    const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
+    const payload: any = { find: vi.fn().mockRejectedValue(new Error('DB error')) }
+    await expect(
+      canUserAccessAction(user, 'articles', 'read', payload, pluginConfig),
+    ).rejects.toThrow('DB error')
+  })
+})

--- a/packages/authorization/src/fields/populateOptions.test.ts
+++ b/packages/authorization/src/fields/populateOptions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { populateOptions } from './populateOptions.js'
+
+describe('populateOptions', () => {
+  const entities = [
+    { label: 'Articles', value: 'articles' },
+    { label: 'Pages', value: 'pages' },
+  ]
+
+  it('sets options on a flat entity select field', () => {
+    const fields: any[] = [{ name: 'entity', type: 'select', options: [] }]
+    populateOptions(fields, entities)
+    expect(fields[0].options).toEqual(entities)
+  })
+
+  it('sets options on a nested entity field inside a group', () => {
+    const fields: any[] = [
+      {
+        name: 'permissions',
+        type: 'array',
+        fields: [{ name: 'entity', type: 'select', options: [] }],
+      },
+    ]
+    populateOptions(fields, entities)
+    expect(fields[0].fields[0].options).toEqual(entities)
+  })
+
+  it('sets options on entity fields inside tabs', () => {
+    const fields: any[] = [
+      {
+        type: 'tabs',
+        tabs: [
+          {
+            fields: [{ name: 'entity', type: 'select', options: [] }],
+          },
+        ],
+      },
+    ]
+    populateOptions(fields, entities)
+    expect(fields[0].tabs[0].fields[0].options).toEqual(entities)
+  })
+
+  it('does not modify fields that are not named entity', () => {
+    const fields: any[] = [{ name: 'title', type: 'text' }]
+    populateOptions(fields, entities)
+    expect((fields[0] as any).options).toBeUndefined()
+  })
+
+  it('handles empty fields array without error', () => {
+    expect(() => populateOptions([], entities)).not.toThrow()
+  })
+})

--- a/packages/authorization/src/utilities/ensurePath.test.ts
+++ b/packages/authorization/src/utilities/ensurePath.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { ensurePath } from './ensurePath.js'
+
+describe('ensurePath', () => {
+  it('creates nested keys that do not exist', () => {
+    const obj: any = {}
+    const result = ensurePath(obj, ['a', 'b', 'c'])
+    expect(obj.a.b.c).toEqual({})
+    expect(result).toBe(obj.a.b.c)
+  })
+
+  it('does not overwrite existing nested objects', () => {
+    const obj: any = { a: { b: { existing: true } } }
+    ensurePath(obj, ['a', 'b', 'c'])
+    expect(obj.a.b.existing).toBe(true)
+    expect(obj.a.b.c).toEqual({})
+  })
+
+  it('returns the leaf object', () => {
+    const obj: any = {}
+    const leaf = ensurePath(obj, ['x', 'y'])
+    leaf.value = 42
+    expect(obj.x.y.value).toBe(42)
+  })
+
+  it('handles a single-element path', () => {
+    const obj: any = {}
+    ensurePath(obj, ['key'])
+    expect(obj.key).toEqual({})
+  })
+
+  it('handles an empty path by returning the root object', () => {
+    const obj: any = { root: true }
+    const result = ensurePath(obj, [])
+    expect(result).toBe(obj)
+  })
+})

--- a/packages/cross-collection/package.json
+++ b/packages/cross-collection/package.json
@@ -32,10 +32,12 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cross-collection/src/index.test.ts
+++ b/packages/cross-collection/src/index.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import CrossCollectionConfig, { ensurePath } from './index.js'
+
+describe('ensurePath', () => {
+  it('creates nested keys that do not exist', () => {
+    const obj: any = {}
+    const result = ensurePath(obj, ['a', 'b'])
+    expect(obj.a.b).toEqual({})
+    expect(result).toBe(obj.a.b)
+  })
+
+  it('does not overwrite existing values', () => {
+    const obj: any = { a: { existing: true } }
+    ensurePath(obj, ['a', 'b'])
+    expect(obj.a.existing).toBe(true)
+    expect(obj.a.b).toEqual({})
+  })
+
+  it('returns the leaf object so callers can assign to it', () => {
+    const obj: any = {}
+    const leaf = ensurePath(obj, ['x', 'y'])
+    leaf.Component = 'MyComponent'
+    expect(obj.x.y.Component).toBe('MyComponent')
+  })
+})
+
+describe('CrossCollectionConfig', () => {
+  it('returns config unchanged when no collections or globals', () => {
+    const config: any = { collections: [], globals: [] }
+    const result = CrossCollectionConfig()(config)
+    expect(result.collections).toEqual([])
+    expect(result.globals).toEqual([])
+  })
+
+  it('applies customOverrides to all collections by default', () => {
+    const MyComponent = () => null
+    const config: any = {
+      collections: [{ slug: 'articles', fields: [] }, { slug: 'pages', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.collections[0].admin.components.edit.Component).toBe(MyComponent)
+    expect(result.collections[1].admin.components.edit.Component).toBe(MyComponent)
+  })
+
+  it('excludes specified collections from overrides', () => {
+    const MyComponent = () => null
+    const config: any = {
+      collections: [{ slug: 'articles', fields: [] }, { slug: 'pages', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      excludedCollections: ['pages'],
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.collections[0].admin.components.edit.Component).toBe(MyComponent)
+    expect(result.collections[1].admin).toBeUndefined()
+  })
+
+  it('applies customOverrides to globals', () => {
+    const MyComponent = () => null
+    const config: any = {
+      globals: [{ slug: 'settings', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.globals[0].admin.components.edit.Component).toBe(MyComponent)
+  })
+
+  it('excludes specified globals from overrides', () => {
+    const MyComponent = () => null
+    const config: any = {
+      globals: [{ slug: 'settings', fields: [] }, { slug: 'nav', fields: [] }],
+    }
+    const result = CrossCollectionConfig({
+      excludedGlobals: ['nav'],
+      customOverrides: { 'admin.components.edit': MyComponent },
+    })(config)
+    expect(result.globals[0].admin.components.edit.Component).toBe(MyComponent)
+    expect(result.globals[1].admin).toBeUndefined()
+  })
+
+  it('handles missing collections gracefully', () => {
+    const config: any = { globals: [] }
+    expect(() => CrossCollectionConfig()(config)).not.toThrow()
+  })
+
+  it('handles missing globals gracefully', () => {
+    const config: any = { collections: [] }
+    expect(() => CrossCollectionConfig()(config)).not.toThrow()
+  })
+
+  it('uses empty defaults when no pluginConfig is provided', () => {
+    const config: any = { collections: [{ slug: 'articles', fields: [] }] }
+    const result = CrossCollectionConfig()(config)
+    expect(result.collections[0].admin).toBeUndefined()
+  })
+})

--- a/packages/custom-version-view/package.json
+++ b/packages/custom-version-view/package.json
@@ -31,13 +31,15 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
     "mongodb": "^6.0.0",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "moment": "^2.30.1"

--- a/packages/custom-version-view/src/getLatestVersion.test.ts
+++ b/packages/custom-version-view/src/getLatestVersion.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getLatestVersion } from './getLatestVersion.js'
+
+function makePayload({
+  findVersionsDocs = [],
+  findGlobalVersionsDocs = [],
+}: {
+  findVersionsDocs?: any[]
+  findGlobalVersionsDocs?: any[]
+} = {}) {
+  return {
+    findVersions: vi.fn().mockResolvedValue({ docs: findVersionsDocs }),
+    findGlobalVersions: vi.fn().mockResolvedValue({ docs: findGlobalVersionsDocs }),
+  } as any
+}
+
+describe('getLatestVersion', () => {
+  it('returns null when no versions found for a collection', async () => {
+    const payload = makePayload()
+    const result = await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '123',
+      payload,
+      status: 'published',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns id and updatedAt for the latest collection version', async () => {
+    const payload = makePayload({
+      findVersionsDocs: [{ id: 'v1', updatedAt: '2024-01-01T00:00:00.000Z' }],
+    })
+    const result = await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '123',
+      payload,
+      status: 'published',
+    })
+    expect(result).toEqual({ id: 'v1', updatedAt: '2024-01-01T00:00:00.000Z' })
+  })
+
+  it('calls findVersions with correct where clause for collection', async () => {
+    const payload = makePayload({
+      findVersionsDocs: [{ id: 'v1', updatedAt: '2024-01-01T00:00:00.000Z' }],
+    })
+    await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '42',
+      payload,
+      status: 'draft',
+    })
+    expect(payload.findVersions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'articles',
+        where: expect.objectContaining({
+          and: expect.arrayContaining([
+            { 'version._status': { equals: 'draft' } },
+            { parent: { equals: '42' } },
+          ]),
+        }),
+      }),
+    )
+  })
+
+  it('calls findGlobalVersions for global type', async () => {
+    const payload = makePayload({
+      findGlobalVersionsDocs: [{ id: 'gv1', updatedAt: '2024-06-01T00:00:00.000Z' }],
+    })
+    const result = await getLatestVersion({
+      slug: 'settings',
+      type: 'global',
+      payload,
+      status: 'published',
+    })
+    expect(payload.findGlobalVersions).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'settings' }),
+    )
+    expect(result).toEqual({ id: 'gv1', updatedAt: '2024-06-01T00:00:00.000Z' })
+  })
+
+  it('returns null when no global versions found', async () => {
+    const payload = makePayload()
+    const result = await getLatestVersion({
+      slug: 'settings',
+      type: 'global',
+      payload,
+      status: 'published',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('does not add parent filter when parentID is not provided', async () => {
+    const payload = makePayload()
+    await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      payload,
+      status: 'published',
+    })
+    const callArg = payload.findVersions.mock.calls[0][0]
+    const hasParentFilter = callArg.where.and.some((c: any) => 'parent' in c)
+    expect(hasParentFilter).toBe(false)
+  })
+
+  it('returns null and does not throw on payload error', async () => {
+    const payload: any = {
+      findVersions: vi.fn().mockRejectedValue(new Error('DB error')),
+      findGlobalVersions: vi.fn(),
+    }
+    const result = await getLatestVersion({
+      slug: 'articles',
+      type: 'collection',
+      parentID: '1',
+      payload,
+      status: 'published',
+    })
+    expect(result).toBeNull()
+  })
+})

--- a/packages/icon-select/package.json
+++ b/packages/icon-select/package.json
@@ -32,13 +32,15 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
     "tailwindcss": "^3.4.14",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.2",

--- a/packages/icon-select/src/lib/getLabelString.test.ts
+++ b/packages/icon-select/src/lib/getLabelString.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { getLabelString } from './getLabelString.js'
+
+describe('getLabelString (icon-select)', () => {
+  it('returns the string as-is when label is a plain string', () => {
+    expect(getLabelString('My Icon')).toBe('My Icon')
+  })
+
+  it('returns the first value when label is an i18n object', () => {
+    expect(getLabelString({ en: 'Icon', fr: 'Icône' })).toBe('Icon')
+  })
+
+  it('returns fallback "Icon" when label is false', () => {
+    expect(getLabelString(false)).toBe('Icon')
+  })
+
+  it('returns fallback "Icon" when label is undefined', () => {
+    expect(getLabelString(undefined)).toBe('Icon')
+  })
+
+  it('uses a custom fallback when provided', () => {
+    expect(getLabelString(undefined, 'Pick Icon')).toBe('Pick Icon')
+  })
+
+  it('returns fallback for an empty i18n object', () => {
+    expect(getLabelString({})).toBe('Icon')
+  })
+})

--- a/packages/icon-select/src/lib/getLabelString.ts
+++ b/packages/icon-select/src/lib/getLabelString.ts
@@ -1,0 +1,15 @@
+/**
+ * Safely extracts a display string from a Payload field label.
+ * The label can be a plain string, an i18n object ({ en: 'Icon', ... }),
+ * false, or undefined.
+ */
+export function getLabelString(
+  label: string | Record<string, string> | false | undefined,
+  fallback = 'Icon',
+): string {
+  if (typeof label === 'string') return label
+  if (label && typeof label === 'object') {
+    return (Object.values(label)[0] as string) ?? fallback
+  }
+  return fallback
+}

--- a/packages/icon-select/src/lib/utils.test.ts
+++ b/packages/icon-select/src/lib/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils.js'
+
+describe('cn', () => {
+  it('returns a single class name unchanged', () => {
+    expect(cn('foo')).toBe('foo')
+  })
+
+  it('merges multiple class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles conditional classes (falsy values are ignored)', () => {
+    expect(cn('foo', false && 'bar', undefined, null, 'baz')).toBe('foo baz')
+  })
+
+  it('deduplicates conflicting tailwind classes (last wins)', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('merges tailwind utility conflicts correctly', () => {
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500')
+  })
+
+  it('returns empty string when no arguments provided', () => {
+    expect(cn()).toBe('')
+  })
+
+  it('handles array-style clsx inputs', () => {
+    expect(cn(['foo', 'bar'])).toBe('foo bar')
+  })
+})

--- a/packages/icon-select/src/selectIcons.tsx
+++ b/packages/icon-select/src/selectIcons.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useField } from '@payloadcms/ui';
 import { FieldLabel as Label } from '@payloadcms/ui';
 import { cn } from './lib/utils';
+import { getLabelString } from './lib/getLabelString';
 import { Button } from './components/button';
 import {
   Command,
@@ -49,7 +50,6 @@ const createIconOptions = () => {
 const icons = createIconOptions();
 const SelectIcons: React.FC<Props> = (props) => {
   const { field, path } = props;
-  const label = field.label;
   const { value, setValue } = useField<string>({ path: path });
   const [open, setOpen] = useState(false);
   const [selectIcon, setSelectIcon] = useState(icons.find((icon) => icon.value === value) || null);
@@ -59,7 +59,7 @@ const SelectIcons: React.FC<Props> = (props) => {
     setValue(value);
     setOpen(false);
   };
-  const labelToUse = label ? label : 'Icon';
+  const labelToUse = getLabelString(field.label);
   return (
     <div className='comp'>
       <Label

--- a/packages/quickfilter/package.json
+++ b/packages/quickfilter/package.json
@@ -40,7 +40,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install"
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@swc/cli": "^0.1.65",
@@ -54,7 +55,8 @@
     "rimraf": "^5.0.5",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "3.4.17",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/packages/quickfilter/src/lib/getLabelString.test.ts
+++ b/packages/quickfilter/src/lib/getLabelString.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { getLabelString } from './getLabelString.js'
+
+describe('getLabelString (quickfilter)', () => {
+  it('returns the string as-is when label is a plain string', () => {
+    expect(getLabelString('Status', 'status')).toBe('Status')
+  })
+
+  it('returns the first value when label is an i18n object', () => {
+    expect(getLabelString({ en: 'Status', fr: 'Statut' }, 'status')).toBe('Status')
+  })
+
+  it('returns fallback when label is false', () => {
+    expect(getLabelString(false, 'fieldName')).toBe('fieldName')
+  })
+
+  it('returns fallback when label is undefined', () => {
+    expect(getLabelString(undefined, 'fieldName')).toBe('fieldName')
+  })
+
+  it('returns fallback for an empty i18n object', () => {
+    expect(getLabelString({}, 'fieldName')).toBe('fieldName')
+  })
+
+  it('uses fieldName as fallback (mimics processNavGroups usage)', () => {
+    expect(getLabelString(undefined, 'createdAt')).toBe('createdAt')
+  })
+})

--- a/packages/quickfilter/src/lib/getLabelString.ts
+++ b/packages/quickfilter/src/lib/getLabelString.ts
@@ -1,0 +1,15 @@
+/**
+ * Safely extracts a display string from a Payload field label.
+ * The label can be a plain string, an i18n object ({ en: 'Title', ... }),
+ * false, or undefined.
+ */
+export function getLabelString(
+  label: string | Record<string, string> | false | undefined,
+  fallback: string,
+): string {
+  if (typeof label === 'string') return label
+  if (label && typeof label === 'object') {
+    return (Object.values(label)[0] as string) ?? fallback
+  }
+  return fallback
+}

--- a/packages/quickfilter/src/lib/utils.ts
+++ b/packages/quickfilter/src/lib/utils.ts
@@ -8,6 +8,7 @@ import type {
   SelectFilterValue,
 } from '../filters/types/filters-type';
 import { SupportedLocale } from '../labels';
+import { getLabelString } from './getLabelString';
 import { futureOptionKeys, pastOptionKeys } from '../filters/constants/date-filter-options';
 import { getDateRangeForOption } from '../filters/utils/date-helpers';
 import type { Field, FieldAffectingData, SelectField, UIField } from 'payload';
@@ -410,7 +411,7 @@ export function processNavGroups(
                   name: fieldName,
                   type: fieldConfig?.type,
                   options: (fieldConfig as SelectField)?.options,
-                  label: (fieldConfig as UIField)?.label || fieldName,
+                  label: getLabelString((fieldConfig as UIField)?.label, fieldName),
                   row: 0,
                   virtual: 'virtual' in fieldConfig && fieldConfig.virtual,
                 } as FilterDetaild;

--- a/packages/reset-list-view/src/index.test.ts
+++ b/packages/reset-list-view/src/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { CollectionResetPreferencesPlugin } from './index.js'
+
+const RESET_BUTTON_PATH = '@shefing/reset-list-view/ResetListViewButton#ResetListViewButton'
+
+function makeConfig(collections: any[] = [], extra: any = {}) {
+  return { collections, ...extra } as any
+}
+
+describe('CollectionResetPreferencesPlugin', () => {
+  it('returns config unchanged when disabled', () => {
+    const config = makeConfig([{ slug: 'articles', fields: [] }])
+    const result = CollectionResetPreferencesPlugin({ disabled: true })(config)
+    expect(result).toBe(config)
+  })
+
+  it('initializes collections array when missing', () => {
+    const config: any = {}
+    const result = CollectionResetPreferencesPlugin({})(config)
+    expect(Array.isArray(result.collections)).toBe(true)
+  })
+
+  it('adds reset button to all collections by default', () => {
+    const config = makeConfig([
+      { slug: 'articles', fields: [] },
+      { slug: 'pages', fields: [] },
+    ])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    for (const col of result.collections) {
+      const items = col.admin.components.listMenuItems
+      expect(items.some((i: any) => i.path === RESET_BUTTON_PATH)).toBe(true)
+    }
+  })
+
+  it('adds reset button only to includedCollections', () => {
+    const config = makeConfig([
+      { slug: 'articles', fields: [] },
+      { slug: 'pages', fields: [] },
+    ])
+    const result = CollectionResetPreferencesPlugin({ includedCollections: ['articles'] })(config)
+    const articles = result.collections.find((c: any) => c.slug === 'articles')
+    const pages = result.collections.find((c: any) => c.slug === 'pages')
+    expect(articles.admin.components.listMenuItems.some((i: any) => i.path === RESET_BUTTON_PATH)).toBe(true)
+    expect(pages.admin).toBeUndefined()
+  })
+
+  it('skips excludedCollections', () => {
+    const config = makeConfig([
+      { slug: 'articles', fields: [] },
+      { slug: 'pages', fields: [] },
+    ])
+    const result = CollectionResetPreferencesPlugin({ excludedCollections: ['pages'] })(config)
+    const articles = result.collections.find((c: any) => c.slug === 'articles')
+    const pages = result.collections.find((c: any) => c.slug === 'pages')
+    expect(articles.admin.components.listMenuItems.some((i: any) => i.path === RESET_BUTTON_PATH)).toBe(true)
+    expect(pages.admin).toBeUndefined()
+  })
+
+  it('passes the correct slug as clientProps', () => {
+    const config = makeConfig([{ slug: 'articles', fields: [] }])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    const items = result.collections[0].admin.components.listMenuItems
+    const btn = items.find((i: any) => i.path === RESET_BUTTON_PATH)
+    expect(btn.clientProps.slug).toBe('articles')
+  })
+
+  it('appends to existing listMenuItems array', () => {
+    const existingItem = { path: 'some/other/component' }
+    const config = makeConfig([
+      {
+        slug: 'articles',
+        fields: [],
+        admin: { components: { listMenuItems: [existingItem] } },
+      },
+    ])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    const items = result.collections[0].admin.components.listMenuItems
+    expect(items).toHaveLength(2)
+    expect(items[0]).toBe(existingItem)
+    expect(items[1].path).toBe(RESET_BUTTON_PATH)
+  })
+
+  it('converts non-array listMenuItems to array before appending', () => {
+    const existingItem = { path: 'some/other/component' }
+    const config = makeConfig([
+      {
+        slug: 'articles',
+        fields: [],
+        admin: { components: { listMenuItems: existingItem } },
+      },
+    ])
+    const result = CollectionResetPreferencesPlugin({})(config)
+    const items = result.collections[0].admin.components.listMenuItems
+    expect(Array.isArray(items)).toBe(true)
+    expect(items).toHaveLength(2)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/authors-info:
     dependencies:
@@ -266,6 +269,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/custom-version-view:
     dependencies:
@@ -285,6 +291,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/field-type-components-override:
     devDependencies:
@@ -346,6 +355,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/quickfilter:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/reset-list-view:
     dependencies:


### PR DESCRIPTION
### Description
This PR implements the CI/CD test strategy as discussed in #86.

### Changes
- Added `.github/workflows/ci.yaml`: Runs Vitest integration tests on every push to any branch.
- Added `.github/workflows/ci-e2e.yaml`: Runs Playwright E2E tests on pull requests to `main` and pushes to `main`.
- Updated `.github/workflows/publish-package.yaml`: Added a `test-before-publish` job that runs both Vitest and Playwright tests before allowing a package to be published.

### Verification
- GitHub Actions will run these workflows upon PR creation.
- Secrets `MONGODB_URI` and `PAYLOAD_SECRET` are required for E2E tests and have been added to the repository.