### PR TITLE
Fix CI pnpm version mismatch

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 9.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 9.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 9.4.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
This PR fixes the CI failure caused by a `pnpm` version mismatch. 
The workflows were configured to use `pnpm@10`, but the project's `package.json` specifies `pnpm@9.4.0`.

Changes:
- Updated `.github/workflows/ci.yaml` to use `pnpm@9.4.0`.
- Updated `.github/workflows/ci-e2e.yaml` to use `pnpm@9.4.0`.
- Updated `.github/workflows/publish-package.yaml` to use `pnpm@9.4.0`.

Linked issue: https://github.com/shefing/payload-tools/actions/runs/25368192720/job/74384466694