### PR TITLE
Fix: Remove pnpm version from CI to resolve conflict with package.json

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
This PR removes the explicit `version` key from `pnpm/action-setup` in the GitHub Action workflows.

The previous error "Multiple versions of pnpm specified" occurred because `pnpm/action-setup` was trying to use the version provided in the `with: version:` block while also finding a `packageManager` field in `package.json`.

By removing the `version` from the workflow files, `pnpm/action-setup` will automatically use the version specified in `package.json`, resolving the conflict.