### PR TITLE
Fix: switch vitest environment from jsdom to happy-dom to fix CI

### DIFF
--- a/test-app/vitest.config.mts
+++ b/test-app/vitest.config.mts
@@ -5,7 +5,7 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
-    environment: 'jsdom',
+    environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['tests/int/**/*.int.spec.ts'],
   },


### PR DESCRIPTION
## Problem
CI was failing with:
```
Error: Cannot find module 'undici/lib/handler/wrap-handler.js'
```
jsdom@28 requires a newer version of `undici` than what's available in the CI environment.

## Fix
Switch vitest test environment from `jsdom` to `happy-dom` (already installed as a dependency). This avoids the undici dependency chain entirely while providing equivalent DOM simulation for the integration tests.