### PR TITLE
Fix: change build filter from @payload-tools/* to @shefing/* so packages are built in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "build": "turbo build --filter \"@payload-tools/*\"",
+    "build": "turbo build --filter \"@shefing/*\"",
     "dev": "pnpm --filter test dev",
     "dev:types": "cd test && pnpm generate:types",
     "test": "cd test && pnpm test",


### PR DESCRIPTION
## Problem

The root `build` script was using `--filter "@payload-tools/*"` but all packages are named `@shefing/*`. This meant `pnpm build` in CI built nothing, causing the vitest run to fail with:

```
Error: Failed to resolve entry for package "@shefing/authorization"
```

## Fix

Changed the filter in `package.json` to `--filter "@shefing/*"` so all workspace packages are actually built before tests run.