### PR TITLE
Fix: exclude test files from cross-collection tsconfig to fix build

### DIFF
--- a/packages/cross-collection/tsconfig.json
+++ b/packages/cross-collection/tsconfig.json
@@ -22,5 +22,5 @@
     "target": "ESNext"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
 }


### PR DESCRIPTION
## Problem

The `tsc --emitDeclarationOnly` step in `@shefing/cross-collection` build was failing because `src/index.test.ts` was included in compilation and referenced Payload types that no longer have `.Component` and `.edit` properties.

## Fix

Added `src/**/*.test.ts` and related patterns to the `exclude` list in `packages/cross-collection/tsconfig.json` so test files are not processed during the declaration emit build step.