### PR TITLE
Fix: exclude test files from reset-list-view tsconfig to fix CI build

### DIFF
--- a/packages/reset-list-view/tsconfig.json
+++ b/packages/reset-list-view/tsconfig.json
@@ -31,4 +31,13 @@
     "./src/**/*.tsx",
     "./dev/next-env.d.ts",
   ],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
## Problem

`@shefing/reset-list-view` build fails in CI because `tsc` processes `src/index.test.ts`, which contains TypeScript errors (strict null checks on optional properties).

## Fix

Added `exclude` array to `packages/reset-list-view/tsconfig.json` to skip all test/spec files during the declaration emit build — same fix applied to `cross-collection` in PR #105.