### PR TITLE
Fix: run package unit tests directly in CI instead of test-app integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,5 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Run Vitest (integration tests)
-        run: pnpm --filter @shefing/dev-app test:int
+      - name: Run Vitest (package unit tests)
+        run: pnpm test:packages

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -42,8 +42,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - name: Run Vitest
-        run: pnpm --filter @shefing/dev-app test:int
+      - name: Run Vitest (package unit tests)
+        run: pnpm test:packages
       - name: Install Playwright browsers
         run: pnpm --filter @shefing/dev-app exec playwright install --with-deps chromium
       - name: Build test-app

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "index.js",
   "scripts": {
     "build": "turbo build --filter \"@shefing/*\"",
+    "test:packages": "vitest run --config ./vitest.config.mts",
     "dev": "pnpm --filter test dev",
     "dev:types": "cd test && pnpm generate:types",
     "test": "cd test && pnpm test",
@@ -38,7 +39,8 @@
     "eslint-config-next": "15.0.0-rc.0",
     "@swc/cli": "^0.1.65",
     "@swc/core": "^1.6.3",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "vitest": "4.0.18"
   },
   "pnpm": {
     "overrides": {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['packages/*/src/**/*.test.ts', 'packages/*/src/**/*.spec.ts'],
+  },
+})


### PR DESCRIPTION
## Problem

CI was running `pnpm --filter @shefing/dev-app test:int` which initializes Payload CMS with a real MongoDB connection in `beforeAll`, causing a 10s timeout in CI where no MongoDB is available.

## Root Cause

The `test:int` script in `test-app` is an integration test that requires a live database. The actual unit tests we want to run are in `packages/*/src/**/*.test.ts`.

## Fix

- Added `vitest.config.mts` at the root that globs all package test files (`packages/*/src/**/*.test.ts`)
- Added `test:packages` script to root `package.json`
- Added `vitest` to root `devDependencies`
- Updated `ci.yaml` and `publish-package.yaml` to run `pnpm test:packages` instead of `@shefing/dev-app test:int`

These tests are pure unit tests with no database dependency and will run reliably in CI.