### PR TITLE
Fix: use DATABASE_URL instead of MONGODB_URI in E2E workflows

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -31,14 +31,14 @@ jobs:
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Run Playwright E2E tests
         run: pnpm --filter @shefing/dev-app test:e2e
         env:
           CI: true
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Upload Playwright report

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -49,13 +49,13 @@ jobs:
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
       - name: Run Playwright E2E
         run: pnpm --filter @shefing/dev-app test:e2e
         env:
           CI: true
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
   validate:


### PR DESCRIPTION
## Problem

The E2E CI job was failing with:
```
cannot connect to MongoDB: connect ECONNREFUSED 127.0.0.1:27017
```

The workflow was passing `MONGODB_URI` as an env var, but `test-app/src/payload.config.ts` reads `process.env.DATABASE_URL` for the database connection string.

## Fix

Renamed `MONGODB_URI` → `DATABASE_URL` in both the build and test steps of `ci-e2e.yaml` and `publish-package.yaml`, so the secret value is correctly picked up by the app.