### PR TITLE
Fix: use secrets.DATABASE_URL instead of secrets.MONGODB_URI in E2E workflows

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -31,14 +31,14 @@ jobs:
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:
-          DATABASE_URL: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Run Playwright E2E tests
         run: pnpm --filter @shefing/dev-app test:e2e
         env:
           CI: true
-          DATABASE_URL: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Upload Playwright report

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -49,13 +49,13 @@ jobs:
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:
-          DATABASE_URL: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
       - name: Run Playwright E2E
         run: pnpm --filter @shefing/dev-app test:e2e
         env:
           CI: true
-          DATABASE_URL: ${{ secrets.MONGODB_URI }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
   validate:


### PR DESCRIPTION
## Problem

E2E tests fail with `connect ECONNREFUSED 127.0.0.1:27017` because the workflow was referencing `secrets.MONGODB_URI` but the GitHub secret is named `DATABASE_URL` (matching the `.env.example` and `payload.config.ts`).

## Fix

Changed `secrets.MONGODB_URI` → `secrets.DATABASE_URL` in both:
- `.github/workflows/ci-e2e.yaml`
- `.github/workflows/publish-package.yaml`