### PR TITLE
Fix: use secrets.MONGODB_URI mapped to DATABASE_URL in E2E workflows

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -31,14 +31,14 @@ jobs:
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Run Playwright E2E tests
         run: pnpm --filter @shefing/dev-app test:e2e
         env:
           CI: true
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Upload Playwright report

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -49,13 +49,13 @@ jobs:
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
       - name: Run Playwright E2E
         run: pnpm --filter @shefing/dev-app test:e2e
         env:
           CI: true
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.MONGODB_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
 
   validate:


### PR DESCRIPTION
## Problem
The E2E workflows were referencing `secrets.DATABASE_URL` which doesn't exist in the repository secrets. The actual secret name is `MONGODB_URI`, causing the app to fall back to `127.0.0.1:27017` and fail to connect to MongoDB.

## Fix
- `ci-e2e.yaml`: changed `${{ secrets.DATABASE_URL }}` → `${{ secrets.MONGODB_URI }}` (keeping the env var name as `DATABASE_URL` since that's what the app reads via `process.env.DATABASE_URL`)
- `publish-package.yaml`: same fix in the `test-before-publish` job