### PR TITLE
Fix: add MongoDB Atlas IP whitelisting to E2E workflows

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -28,6 +28,13 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter @shefing/dev-app exec playwright install --with-deps chromium
 
+      - name: Permit runner to access MongoDB Atlas
+        uses: textbook/atlas-ip@v1
+        with:
+          atlas-private-key: ${{ secrets.ATLAS_PRIVATE_KEY }}
+          atlas-public-key: ${{ secrets.ATLAS_PUBLIC_KEY }}
+          group-id: ${{ vars.ATLAS_GROUP_ID }}
+
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -46,6 +46,12 @@ jobs:
         run: pnpm test:packages
       - name: Install Playwright browsers
         run: pnpm --filter @shefing/dev-app exec playwright install --with-deps chromium
+      - name: Permit runner to access MongoDB Atlas
+        uses: textbook/atlas-ip@v1
+        with:
+          atlas-private-key: ${{ secrets.ATLAS_PRIVATE_KEY }}
+          atlas-public-key: ${{ secrets.ATLAS_PUBLIC_KEY }}
+          group-id: ${{ vars.ATLAS_GROUP_ID }}
       - name: Build test-app
         run: pnpm --filter @shefing/dev-app build
         env:


### PR DESCRIPTION
## Problem
E2E tests fail with:
```
Could not connect to any servers in your MongoDB Atlas cluster. One common reason is that you're trying to access the database from an IP that isn't whitelisted.
```
GitHub Actions runners use dynamic IPs that are not whitelisted in MongoDB Atlas by default.

## Fix
Added `textbook/atlas-ip@v1` step before the build/test steps in both `ci-e2e.yaml` and `publish-package.yaml`. This action temporarily adds the runner's current IP to the Atlas IP access list using the Atlas API.

## Required secrets/variables (must be set in GitHub repo settings)
- `ATLAS_PRIVATE_KEY` — MongoDB Atlas API private key
- `ATLAS_PUBLIC_KEY` — MongoDB Atlas API public key
- `ATLAS_GROUP_ID` — MongoDB Atlas project/group ID (as a repository variable, not secret)