### PR TITLE
Fix: restrict Playwright testMatch to e2e dirs to avoid vitest conflict

### DIFF
--- a/test-app/playwright.config.ts
+++ b/test-app/playwright.config.ts
@@ -11,6 +11,7 @@ import 'dotenv/config'
  */
 export default defineConfig({
   testDir: './tests',
+  testMatch: ['**/e2e/**/*.spec.ts', '**/e2e-plugins/**/*.spec.ts'],
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */


### PR DESCRIPTION
## Problem

Playwright's `testDir: './tests'` was picking up files in `tests/int/` (vitest-based integration tests) in addition to `tests/e2e/` and `tests/e2e-plugins/`. This caused `@vitest/expect` to be loaded in the Playwright process, conflicting with Playwright's Jest-compatible matchers:

```
TypeError: Cannot redefine property: Symbol($$jest-matchers-object)
```

## Fix

Added `testMatch` to `playwright.config.ts` to restrict test discovery to only `e2e/` and `e2e-plugins/` directories:

```ts
testMatch: ['**/e2e/**/*.spec.ts', '**/e2e-plugins/**/*.spec.ts'],
```