### PR TITLE
Fix: use REST API for seedTestUser, increase E2E timeouts for CI

### DIFF
--- a/test-app/playwright.config.ts
+++ b/test-app/playwright.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
   testMatch: ['**/e2e/**/*.spec.ts', '**/e2e-plugins/**/*.spec.ts'],
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
+  /* Increase timeout for CI */
+  timeout: process.env.CI ? 60000 : 30000,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */

--- a/test-app/tests/e2e-plugins/helpers.ts
+++ b/test-app/tests/e2e-plugins/helpers.ts
@@ -82,7 +82,7 @@ export async function login(page: Page) {
   await page.fill('input[type="email"]', adminUser.email)
   await page.fill('input[type="password"]', adminUser.password)
   await page.locator('button[type="submit"]').click()
-  await page.waitForURL((url) => !url.href.includes('/admin/login'), { timeout: 15000 })
+  await page.waitForURL((url) => !url.href.includes('/admin/login'), { timeout: 30000 })
   await page.waitForLoadState('domcontentloaded')
 }
 

--- a/test-app/tests/e2e/admin.e2e.spec.ts
+++ b/test-app/tests/e2e/admin.e2e.spec.ts
@@ -29,13 +29,13 @@ test.describe('Admin Panel', () => {
     await page.goto('http://localhost:3000/admin/collections/users')
     await expect(page).toHaveURL('http://localhost:3000/admin/collections/users')
     const listViewArtifact = page.locator('h1', { hasText: 'Users' }).first()
-    await expect(listViewArtifact).toBeVisible()
+    await expect(listViewArtifact).toBeVisible({ timeout: 30000 })
   })
 
   test('can navigate to edit view', async () => {
     await page.goto('http://localhost:3000/admin/collections/users/create')
     await expect(page).toHaveURL(/\/admin\/collections\/users\/[a-zA-Z0-9-_]+/)
     const editViewArtifact = page.locator('input[name="email"]')
-    await expect(editViewArtifact).toBeVisible()
+    await expect(editViewArtifact).toBeVisible({ timeout: 30000 })
   })
 })

--- a/test-app/tests/helpers/login.ts
+++ b/test-app/tests/helpers/login.ts
@@ -24,8 +24,8 @@ export async function login({
   await page.fill('#field-password', user.password)
   await page.click('button[type="submit"]')
 
-  await page.waitForURL(`${serverURL}/admin`)
+  await page.waitForURL(`${serverURL}/admin`, { timeout: 30000 })
 
   const dashboardArtifact = page.locator('span[title="Dashboard"]')
-  await expect(dashboardArtifact).toBeVisible()
+  await expect(dashboardArtifact).toBeVisible({ timeout: 30000 })
 }

--- a/test-app/tests/helpers/seedUser.ts
+++ b/test-app/tests/helpers/seedUser.ts
@@ -1,46 +1,69 @@
-import { getPayload } from 'payload'
-import config from '../../src/payload.config.js'
+import { request as playwrightRequest } from '@playwright/test'
+
+const SERVER_URL = 'http://localhost:3000'
+
+const adminUser = {
+  email: 'admin@payload-tools.dev',
+  password: 'Password1!',
+}
 
 export const testUser = {
   email: 'dev@payloadcms.com',
   password: 'test',
 }
 
-/**
- * Seeds a test user for e2e admin tests.
- */
-export async function seedTestUser(): Promise<void> {
-  const payload = await getPayload({ config })
-
-  // Delete existing test user if any
-  await payload.delete({
-    collection: 'users',
-    where: {
-      email: {
-        equals: testUser.email,
-      },
-    },
-  })
-
-  // Create fresh test user
-  await payload.create({
-    collection: 'users',
-    data: testUser,
-  })
+async function getAdminToken(): Promise<string> {
+  const apiKey = process.env.AUTOMATION_SEED_API_KEY || '3dbb49cb-ce8f-4032-a3df-4ed088d4234c'
+  return `users API-Key ${apiKey}`
 }
 
 /**
- * Cleans up test user after tests
+ * Seeds a test user for e2e admin tests via REST API.
+ */
+export async function seedTestUser(): Promise<void> {
+  const context = await playwrightRequest.newContext({ baseURL: SERVER_URL })
+  const token = await getAdminToken()
+
+  // Find and delete existing test user if any
+  const findRes = await context.get(`/api/users?where[email][equals]=${encodeURIComponent(testUser.email)}&limit=10`, {
+    headers: { Authorization: token },
+  })
+  const findBody = await findRes.json()
+  for (const doc of findBody?.docs ?? []) {
+    await context.delete(`/api/users/${doc.id}`, {
+      headers: { Authorization: token },
+    })
+  }
+
+  // Create fresh test user
+  const createRes = await context.post('/api/users', {
+    headers: { Authorization: token },
+    data: testUser,
+  })
+  if (!createRes.ok()) {
+    const body = await createRes.json()
+    throw new Error(`Failed to create test user: ${JSON.stringify(body)}`)
+  }
+
+  await context.dispose()
+}
+
+/**
+ * Cleans up test user after tests via REST API.
  */
 export async function cleanupTestUser(): Promise<void> {
-  const payload = await getPayload({ config })
+  const context = await playwrightRequest.newContext({ baseURL: SERVER_URL })
+  const token = await getAdminToken()
 
-  await payload.delete({
-    collection: 'users',
-    where: {
-      email: {
-        equals: testUser.email,
-      },
-    },
+  const findRes = await context.get(`/api/users?where[email][equals]=${encodeURIComponent(testUser.email)}&limit=10`, {
+    headers: { Authorization: token },
   })
+  const findBody = await findRes.json()
+  for (const doc of findBody?.docs ?? []) {
+    await context.delete(`/api/users/${doc.id}`, {
+      headers: { Authorization: token },
+    })
+  }
+
+  await context.dispose()
 }


### PR DESCRIPTION
## Problem

Three root causes for E2E failures:

1. **MongoDB transaction aborts** — `seedTestUser` called `getPayload()` which triggered `onInit`/seed, causing `MongoServerError: Transaction aborted` when multiple test workers hit the DB concurrently.
2. **Timeouts too short for CI** — `toBeVisible()` defaulted to 5s, login `waitForURL` was 15s — too short for a cold CI runner.
3. **`can restore a previous version`** — navigation to `/versions` timed out at 15s.

## Fix

- **`tests/helpers/seedUser.ts`**: Replaced `getPayload()` with Playwright REST API calls using the admin API key — no DB connection, no transaction conflicts.
- **`tests/helpers/login.ts`**: Added explicit 30s timeout to `waitForURL` and `toBeVisible`.
- **`tests/e2e/admin.e2e.spec.ts`**: Added 30s timeout to all `toBeVisible` assertions.
- **`tests/e2e-plugins/helpers.ts`**: Increased login `waitForURL` from 15s → 30s.
- **`playwright.config.ts`**: Set global `timeout` to 60s on CI, 30s locally.