### PR TITLE
Fix: handle plain string columns URL param gracefully, remove debug logs

### DIFF
--- a/packages/quickfilter/src/filters/utils/layout-helpers.test.ts
+++ b/packages/quickfilter/src/filters/utils/layout-helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { parseColumns } from './layout-helpers.js'
+
+describe('parseColumns', () => {
+  it('returns array as-is', () => {
+    expect(parseColumns(['title', 'slug'])).toEqual(['title', 'slug'])
+  })
+
+  it('parses a JSON-encoded array string', () => {
+    expect(parseColumns('["title","slug"]')).toEqual(['title', 'slug'])
+  })
+
+  it('handles a plain string column accessor (e.g. from old URL ?columns=title)', () => {
+    expect(parseColumns('title')).toEqual(['title'])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseColumns('')).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(parseColumns('   ')).toEqual([])
+  })
+
+  it('returns empty array for non-string, non-array input', () => {
+    expect(parseColumns(null)).toEqual([])
+    expect(parseColumns(undefined)).toEqual([])
+    expect(parseColumns(42)).toEqual([])
+  })
+
+  it('handles URL-decoded JSON array', () => {
+    const decoded = decodeURIComponent('%5B%22title%22%2C%22slug%22%5D')
+    expect(parseColumns(decoded)).toEqual(['title', 'slug'])
+  })
+})

--- a/packages/quickfilter/src/filters/utils/layout-helpers.ts
+++ b/packages/quickfilter/src/filters/utils/layout-helpers.ts
@@ -68,25 +68,20 @@ export const parseColumns = (raw: unknown): string[] => {
   }
 
   if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+
     try {
-      const cleaned = raw
-        .trim()
-        .replace(/^"+/, '')
-        .replace(/"+$/, '')
-        .replace(/\\"/g, '"')
-        .replace(/\\+"/g, '"')
-        .replace(/\\\\/g, '\\');
-
-      const parsed = JSON.parse(cleaned);
-
+      const parsed = JSON.parse(trimmed);
       if (Array.isArray(parsed)) {
-        console.log('Parsed columns:', parsed);
-        console.log('row:', raw);
         return parsed;
       }
-    } catch (err) {
-      console.warn('Failed to parse columns string:', raw, err);
+    } catch {
+      // Not valid JSON — treat as a single plain column accessor
     }
+
+    // Plain string like "title" — wrap in array
+    return [trimmed];
   }
 
   return [];

--- a/test-app/tests/e2e-plugins/reset-list-view.spec.ts
+++ b/test-app/tests/e2e-plugins/reset-list-view.spec.ts
@@ -52,7 +52,7 @@ test.describe('CollectionResetPreferencesPlugin (@shefing/reset-list-view)', () 
 
   test('reset button removes the columns query param from the URL', async ({ page }) => {
     // Manually add a columns param to simulate a saved preference state
-    await page.goto('/admin/collections/pages?columns=title')
+    await page.goto('/admin/collections/pages?columns=%5B%22title%22%5D')
     await page.waitForURL(/\/admin\/collections\/pages/)
 
     const menuButton = page.locator('.list-controls__view-column-control .popup--type-click')


### PR DESCRIPTION
## Problem

The Payload log showed:
```
Error parsing columns title SyntaxError: Unexpected token 'i', "title" is not valid JSON
    at JSON.parse (<anonymous>)
    at stringify (<anonymous>)
```

This originates from `transformColumnPreferences.ts` line 27 in Payload core, which calls `JSON.parse` on the `columns` URL param. When the param is a plain string like `title` (not a JSON array), it throws.

Two root causes:

1. **`parseColumns` in quickfilter** was stripping quotes and trying `JSON.parse` on the cleaned string — if the value was a plain accessor like `title`, it would fail and return `[]`, silently losing the column. It also had leftover debug `console.log` statements.

2. **E2E test** in `reset-list-view.spec.ts` was navigating to `?columns=title` (plain string), which is invalid — it should be `?columns=%5B%22title%22%5D` (JSON-encoded `["title"]`).

## Fix

- **`parseColumns`**: simplified to try `JSON.parse` directly; if it fails (not valid JSON), treat the raw string as a single-element array `[trimmed]` so old/bookmarked URLs with `?columns=title` are handled gracefully instead of erroring. Removed debug `console.log` statements.
- **E2E test**: changed `?columns=title` → `?columns=%5B%22title%22%5D` to use the correct format.
- **New tests**: added `layout-helpers.test.ts` covering plain string, JSON array, empty, whitespace, non-string, and URL-decoded inputs.
