### PR TITLE
Fix: run only e2e-plugins in CI, fix version restore test timeouts

### DIFF
--- a/test-app/playwright.config.ts
+++ b/test-app/playwright.config.ts
@@ -11,7 +11,7 @@ import 'dotenv/config'
  */
 export default defineConfig({
   testDir: './tests',
-  testMatch: ['**/e2e/**/*.spec.ts', '**/e2e-plugins/**/*.spec.ts'],
+  testMatch: ['**/e2e-plugins/**/*.spec.ts'],
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Increase timeout for CI */

--- a/test-app/tests/e2e-plugins/custom-version-view.spec.ts
+++ b/test-app/tests/e2e-plugins/custom-version-view.spec.ts
@@ -56,13 +56,14 @@ test.describe('versionsPlugin (@shefing/custom-version-view)', () => {
     await saveDraftBtn.waitFor({ state: 'visible' })
     await expect(saveDraftBtn).toBeEnabled({ timeout: 10000 })
     await saveDraftBtn.click()
-    await page.waitForTimeout(500)
+    // Wait for save to complete (button becomes enabled again or network settles)
+    await page.waitForLoadState('networkidle', { timeout: 15000 })
 
     const tab = versionsTab(page)
-    await tab.waitFor({ state: 'visible', timeout: 15000 })
+    await tab.waitFor({ state: 'visible', timeout: 30000 })
     await tab.click()
-    await page.waitForURL(/\/versions/, { timeout: 15000 })
-    await page.waitForLoadState('networkidle', { timeout: 15000 })
+    await page.waitForURL(/\/versions/, { timeout: 30000 })
+    await page.waitForLoadState('networkidle', { timeout: 30000 })
 
     const firstVersionLink = page.getByRole('link').filter({ hasText: /ago|draft|published/i }).first()
     if (await firstVersionLink.isVisible({ timeout: 5000 }).catch(() => false)) {


### PR DESCRIPTION
## Changes

1. **`playwright.config.ts`**: Changed `testMatch` to only include `**/e2e-plugins/**/*.spec.ts` — removes `tests/e2e/` (admin.e2e.spec.ts) from CI runs as requested.

2. **`custom-version-view.spec.ts`**: 
   - Replaced `waitForTimeout(500)` after save draft click with `waitForLoadState('networkidle')` to properly wait for the save to complete before navigating to versions tab.
   - Increased versions tab `waitFor`, `waitForURL`, and `waitForLoadState` timeouts from 15s → 30s to handle CI slowness.