### PR TITLE
feat(changes-button): rename @shefing/review-button → @shefing/changes-button, adopt labels.ts convention

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -10,6 +10,7 @@ on:
         options:
           - authorization
           - authors-info
+          - changes-button
           - color-picker
           - comments
           - cover-image

--- a/.github/workflows/purge-npm-package.yaml
+++ b/.github/workflows/purge-npm-package.yaml
@@ -10,6 +10,7 @@ on:
         options:
           - authorization
           - authors-info
+          - changes-button
           - color-picker
           - comments
           - cover-image

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ next-env.d.ts
 # Ignore any files starting with .terraform at any depth
 **/.terraform*
 
+**/dist/**

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Improve version control with a **custom version view** that displays "**Updated 
 11. **🔄 [Reset List View](packages/reset-list-view/)**  
    Add a "Reset Preferences" button to collection list views, allowing users to quickly reset their list view preferences (columns, filters, pagination, etc.) to the default state.
 
+12. **🔍 [Changes Button](packages/changes-button/)**  
+   Add a **"Changes" button** to drafts-enabled collections and globals that opens a slide-in drawer showing a field-by-field diff between the currently published version and the user's unsaved edits or latest draft — letting editors review exactly what will be published before clicking **Publish**.
+
 ---
 
 💡 **Tip:** Each plugin is modular and can be integrated independently based on your project needs. Check out the linked documentation for installation instructions and configuration details.
@@ -122,6 +125,9 @@ Improve version control with a **custom version view** that displays "**Updated 
 
 11. **🔄 [Reset List View](packages/reset-list-view/)**  
    Add a "Reset Preferences" button to collection list views, allowing users to quickly reset their list view preferences (columns, filters, pagination, etc.) to the default state.
+
+12. **🔍 [Changes Button](packages/changes-button/)**  
+   Add a **"Changes" button** to drafts-enabled collections and globals that opens a slide-in drawer showing a field-by-field diff between the currently published version and the user's unsaved edits or latest draft — letting editors review exactly what will be published before clicking **Publish**.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -47,9 +47,6 @@
       "@types/react": "npm:types-react@19.0.0-rc.0",
       "@types/react-dom": "npm:types-react-dom@19.0.0-rc.0",
       "undici": "^8.1.0",
-      "payload": "3.84.1",
-      "@payloadcms/ui": "3.84.1",
-      "@payloadcms/next": "3.84.1",
       "@payloadcms/richtext-lexical": "3.84.1",
       "react": "19.1.0",
       "react-dom": "19.1.0"

--- a/packages/changes-button/.swcrc
+++ b/packages/changes-button/.swcrc
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": true,
+  "jsc": {
+    "target": "esnext",
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dts": true
+    },
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  },
+  "module": {
+    "type": "es6"
+  }
+}

--- a/packages/changes-button/README.md
+++ b/packages/changes-button/README.md
@@ -1,0 +1,138 @@
+# @shefing/changes-button
+
+A Payload CMS plugin that adds a **Changes** button to drafts-enabled documents. Clicking it opens a slide-in drawer that shows a field-by-field diff between the current document state (or the latest draft) and the currently published version — using the same diff UI as the built-in Versions view.
+
+## Features
+
+- Auto-injects into every drafts-enabled collection / global (no manual component wiring).
+- Visibility is fully driven by document state: the button only shows when there are unpublished changes AND the user has publish permission.
+- Toggle inside the drawer to switch between *Unsaved* (live form values) and *Latest draft* (saved draft) when both exist.
+- Self-contained — the diff renderer is vendored from Payload's Versions view, so the plugin works against any `payload` / `@payloadcms/next` release without waiting for new exports to land upstream.
+- All UI strings live in `src/labels.ts` (en/ar/es/fr/he/zh) and are picked up via `useTranslation().i18n.language`.
+
+## Status
+
+Two upstream Payload PRs would let the plugin install with a single line and zero layout edits, but they have not been merged yet:
+
+| Feature | Issue | PR |
+| --- | --- | --- |
+| `@payloadcms/next/views/diff` subpath export | [#16496](https://github.com/payloadcms/payload/issues/16496) | [#16498](https://github.com/payloadcms/payload/pull/16498) |
+| `config.admin.serverFunctions` registry | [#16497](https://github.com/payloadcms/payload/issues/16497) | [#16499](https://github.com/payloadcms/payload/pull/16499) |
+
+Until they ship, this package vendors the diff pipeline from `@payloadcms/next/src/views/Version/RenderFieldsToDiff/` (see `src/vendor/diff/`) and requires a small `(payload)/layout.tsx` change to register the server function. Once both PRs land, the vendor copy can be deleted and the layout edit removed.
+
+## Install
+
+```sh
+pnpm add @shefing/changes-button
+```
+
+## Usage
+
+### 1. Register the plugin in `payload.config.ts`
+
+```ts
+import { buildConfig } from 'payload'
+import { changesButtonPlugin } from '@shefing/changes-button'
+
+export default buildConfig({
+  // ...
+  plugins: [
+    changesButtonPlugin({
+      // optional — exclude collections / globals from receiving the button
+      excludedCollections: ['users'],
+      excludedGlobals: [],
+    }),
+  ],
+})
+```
+
+### 2. Wrap `handleServerFunctions` in `app/(payload)/layout.tsx`
+
+The plugin needs a server function (`shefing/changes-button:render-diff`) registered alongside Payload's built-in ones. Until upstream PR #16499 lands, this is done by wrapping the `serverFunction` you pass to `<RootLayout />`:
+
+```ts
+// app/(payload)/layout.tsx
+import type { ServerFunctionClient } from 'payload'
+import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
+import { wrapServerFunctions } from '@shefing/changes-button/server'
+import config from '@payload-config'
+import { importMap } from './admin/importMap.js'
+
+const baseServerFunction: ServerFunctionClient = async function (args) {
+  'use server'
+  return handleServerFunctions({ ...args, config, importMap })
+}
+
+const serverFunction = wrapServerFunctions(baseServerFunction)
+
+export default async function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <RootLayout config={config} importMap={importMap} serverFunction={serverFunction}>
+      {children}
+    </RootLayout>
+  )
+}
+```
+
+`wrapServerFunctions` intercepts only the `shefing/changes-button:render-diff` key and forwards every other call to the base handler unchanged.
+
+## Configuration
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `excludedCollections` | `string[]` | `[]` | Slugs of collections that should NOT receive the Changes button. |
+| `excludedGlobals` | `string[]` | `[]` | Slugs of globals that should NOT receive the Changes button. |
+| `disabled` | `boolean` | `false` | Disable the plugin entirely without removing it from `plugins`. |
+
+## When the button appears
+
+The button is rendered only when **all** of the following are true for the open document:
+
+- The entity has drafts enabled (`versions.drafts` is configured).
+- The current user has publish permission.
+- The document is not in trash.
+- There are unpublished changes — either the form is `modified` or `unpublishedVersionCount > 0`.
+
+For brand-new entities (no published baseline) the diff renders against an empty baseline so every populated field shows as an addition.
+
+## Localization
+
+All user-facing strings are declared in [`src/labels.ts`](./src/labels.ts) and consumed via the `getLabel(key, locale)` helper. The active locale is read from `useTranslation().i18n.language` so the button automatically follows the admin UI language.
+
+Built-in locales: `en`, `ar`, `es`, `fr`, `he`, `zh`. Missing keys/locales fall back to English.
+
+## Manual server-function wiring (advanced)
+
+If you don't want to use `wrapServerFunctions`, register the handler explicitly in your `serverFunctions` map:
+
+```ts
+import { renderChangesDiffHandler, SERVER_FUNCTION_KEY } from '@shefing/changes-button/server'
+
+const serverFunction: ServerFunctionClient = async function (args) {
+  'use server'
+  return handleServerFunctions({
+    ...args,
+    config,
+    importMap,
+    serverFunctions: { [SERVER_FUNCTION_KEY]: renderChangesDiffHandler },
+  })
+}
+```
+
+## Local development
+
+The vendored diff pipeline lives in `src/vendor/diff/` — a snapshot of `@payloadcms/next/src/views/Version/RenderFieldsToDiff/` (minus `*.spec.ts`). When upstream PR #16498 ships in a release:
+
+1. Replace the vendor imports in `src/server/renderChangesDiff.tsx` with `import { countChangedFields, RenderDiff } from '@payloadcms/next/views/diff'`.
+2. Delete `src/vendor/diff/` and the copied `SelectedLocalesContext.tsx`.
+3. Bump the `@payloadcms/next` `peerDependency` to the release that exposes the subpath.
+
+When PR #16499 ships, additionally:
+
+1. Re-add `config.admin.serverFunctions` self-registration in `ChangesButtonPlugin.ts` (see git history).
+2. Drop the `wrapServerFunctions` step from this README — the plugin will be a single-line install again.
+
+## License
+
+MIT — © shefing

--- a/packages/changes-button/package.json
+++ b/packages/changes-button/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@shefing/changes-button",
+  "version": "0.1.0",
+  "private": false,
+  "bugs": "https://github.com/shefing/payload-tools/issues",
+  "repository": "https://github.com/shefing/payload-tools",
+  "license": "MIT",
+  "author": "shefing",
+  "type": "module",
+  "main": "dist/ChangesButtonPlugin.js",
+  "module": "dist/ChangesButtonPlugin.js",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/ChangesButtonPlugin.js",
+      "require": "./dist/ChangesButtonPlugin.js"
+    },
+    "./client": {
+      "import": "./dist/index.client.js",
+      "require": "./dist/index.client.js"
+    },
+    "./server": {
+      "import": "./dist/server/index.js",
+      "require": "./dist/server/index.js"
+    }
+  },
+  "scripts": {
+    "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
+    "build:swc": "swc ./src -d ./dist --config-file .swcrc",
+    "build:types": "node --max-old-space-size=8192 ../../node_modules/typescript/bin/tsc --emitDeclarationOnly --noCheck --outDir dist",
+    "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
+    "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
+    "lint": "eslint src",
+    "lint:fix": "eslint --fix --ext .ts,.tsx src",
+    "prepublishOnly": "pnpm clean && pnpm build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "dequal": "^2.0.3"
+  },
+  "peerDependencies": {
+    "@payloadcms/next": ">=3.84.0",
+    "@payloadcms/ui": ">=3.84.0",
+    "payload": ">=3.84.0",
+    "react": ">=19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "19.0.1",
+    "@types/react-dom": "19.0.1",
+    "typescript": "^5.5.2",
+    "vitest": "^3.1.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/changes-button/src/ChangesButtonPlugin.test.ts
+++ b/packages/changes-button/src/ChangesButtonPlugin.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Config } from 'payload'
+
+import { changesButtonPlugin } from './ChangesButtonPlugin.js'
+
+/**
+ * These tests exercise the plugin factory in isolation — they do NOT spin up
+ * Payload. We rely on the public typing of `Config` and check structural
+ * mutations performed by `changesButtonPlugin`.
+ *
+ * Server-function registration is handled by the consumer in
+ * `(payload)/layout.tsx` via `wrapServerFunctions(...)` until Payload PR-B
+ * lands in a release. The plugin factory itself no longer touches
+ * `config.admin.serverFunctions`, so those assertions are gone.
+ */
+type CollectionLike = {
+  slug: string
+  fields: unknown[]
+  versions?: { drafts?: boolean | object }
+  admin?: {
+    components?: {
+      edit?: { beforeDocumentControls?: Array<{ path: string }> }
+    }
+  }
+}
+
+const makeCollection = (slug: string, drafts: boolean): CollectionLike => ({
+  slug,
+  fields: [],
+  versions: drafts ? { drafts: true } : undefined,
+})
+
+const CHANGES_PATH = '@shefing/changes-button/client#ChangesButton'
+
+const beforeControls = (entity: CollectionLike) =>
+  entity.admin?.components?.edit?.beforeDocumentControls
+
+describe('changesButtonPlugin', () => {
+  it('injects the ChangesButton into drafts-enabled collections', () => {
+    const config = {
+      collections: [makeCollection('posts', true), makeCollection('logs', false)],
+    } as unknown as Config
+
+    const out = changesButtonPlugin()(config)
+    const posts = out.collections![0] as unknown as CollectionLike
+    const logs = out.collections![1] as unknown as CollectionLike
+
+    expect(beforeControls(posts)).toEqual([{ path: CHANGES_PATH }])
+    expect(beforeControls(logs)).toBeUndefined()
+  })
+
+  it('honors `excludedCollections`', () => {
+    const config = {
+      collections: [makeCollection('posts', true), makeCollection('pages', true)],
+    } as unknown as Config
+
+    const out = changesButtonPlugin({ excludedCollections: ['pages'] })(config)
+    expect(beforeControls(out.collections![0] as unknown as CollectionLike)).toEqual([
+      { path: CHANGES_PATH },
+    ])
+    expect(beforeControls(out.collections![1] as unknown as CollectionLike)).toBeUndefined()
+  })
+
+  it('injects the ChangesButton into drafts-enabled globals', () => {
+    const config = {
+      globals: [{ slug: 'header', fields: [], versions: { drafts: true } }],
+    } as unknown as Config
+
+    const out = changesButtonPlugin()(config)
+    expect(beforeControls(out.globals![0] as unknown as CollectionLike)).toEqual([
+      { path: CHANGES_PATH },
+    ])
+  })
+
+  it('is idempotent — running the factory twice does not duplicate the button entry', () => {
+    const factory = changesButtonPlugin()
+    const config = { collections: [makeCollection('posts', true)] } as unknown as Config
+
+    const once = factory(config)
+    const twice = factory(once)
+    expect(beforeControls(twice.collections![0] as unknown as CollectionLike)).toEqual([
+      { path: CHANGES_PATH },
+    ])
+  })
+
+  it('returns the config unchanged when `disabled: true`', () => {
+    const config = { collections: [makeCollection('posts', true)] } as unknown as Config
+
+    const out = changesButtonPlugin({ disabled: true })(config)
+    expect(beforeControls(out.collections![0] as unknown as CollectionLike)).toBeUndefined()
+  })
+})

--- a/packages/changes-button/src/ChangesButtonPlugin.ts
+++ b/packages/changes-button/src/ChangesButtonPlugin.ts
@@ -1,0 +1,119 @@
+import type { Config, PayloadComponent } from 'payload'
+
+import { hasDraftsEnabled } from 'payload/shared'
+
+export interface ChangesButtonPluginConfig {
+  /** Slugs of collections that should NOT receive the Changes button. */
+  excludedCollections?: string[]
+  /** Slugs of globals that should NOT receive the Changes button. */
+  excludedGlobals?: string[]
+  /** Disable the plugin entirely without removing it from `plugins`. */
+  disabled?: boolean
+}
+
+const defaultConfig: Required<Omit<ChangesButtonPluginConfig, 'disabled'>> & {
+  disabled: boolean
+} = {
+  excludedCollections: [],
+  excludedGlobals: [],
+  disabled: false,
+}
+
+const CHANGES_BUTTON_COMPONENT: PayloadComponent = {
+  path: '@shefing/changes-button/client#ChangesButton',
+}
+
+/**
+ * Pushes the ChangesButton into the `beforeDocumentControls` slot of an entity's
+ * edit view, idempotently (won't double-add on repeated runs).
+ */
+function injectButton(
+  entity: { admin?: { components?: Record<string, unknown> } & Record<string, unknown> } & Record<
+    string,
+    unknown
+  >,
+): void {
+  // Defensive object construction — mirrors the `ensurePath` pattern used by
+  // `@shefing/custom-version-view`.
+  const admin = ((entity.admin as Record<string, unknown> | undefined) ?? (entity.admin = {})) as {
+    components?: {
+      edit?: { beforeDocumentControls?: PayloadComponent[] } & Record<string, unknown>
+    } & Record<string, unknown>
+  }
+  const components = (admin.components ?? (admin.components = {})) as {
+    edit?: { beforeDocumentControls?: PayloadComponent[] } & Record<string, unknown>
+  }
+  const edit = (components.edit ?? (components.edit = {})) as {
+    beforeDocumentControls?: PayloadComponent[]
+  }
+  const arr = (edit.beforeDocumentControls ?? (edit.beforeDocumentControls = [])) as Array<
+    PayloadComponent | string
+  >
+
+  // Idempotency check — match by `path` if present. `PayloadComponent` is
+  // `string | { path?: string; ... }` so we narrow before reading `.path`.
+  const targetPath =
+    typeof CHANGES_BUTTON_COMPONENT === 'string'
+      ? CHANGES_BUTTON_COMPONENT
+      : (CHANGES_BUTTON_COMPONENT as { path?: string }).path
+  const alreadyPresent = arr.some((c) => {
+    if (typeof c === 'string') {
+      return c === targetPath
+    }
+    return c && (c as { path?: string }).path === targetPath
+  })
+  if (!alreadyPresent) {
+    arr.push(CHANGES_BUTTON_COMPONENT)
+  }
+}
+
+/**
+ * `changesButtonPlugin` adds a "Changes" button to every drafts-enabled
+ * collection and global edit view. Clicking it opens a diff between the
+ * current document state (or the latest draft) and the latest published
+ * version, reusing the same diff UI as the built-in Versions view.
+ *
+ * Server function registration: until Payload merges PR-B
+ * (`config.admin.serverFunctions` registry), the consumer must wire the
+ * plugin's server function into `(payload)/layout.tsx` themselves using
+ * the `wrapServerFunctions` helper exported from this package. See README.
+ */
+export const changesButtonPlugin =
+  (pluginConfig: ChangesButtonPluginConfig = {}) =>
+  (config: Config): Config => {
+    const merged = { ...defaultConfig, ...pluginConfig }
+
+    if (merged.disabled) {
+      return config
+    }
+
+    // 1. Inject button into drafts-enabled collections.
+    if (Array.isArray(config.collections)) {
+      for (const collection of config.collections) {
+        if (merged.excludedCollections.includes(collection.slug)) {
+          continue
+        }
+        if (!hasDraftsEnabled(collection)) {
+          continue
+        }
+        injectButton(collection as unknown as Record<string, unknown>)
+      }
+    }
+
+    // 2. Inject button into drafts-enabled globals.
+    if (Array.isArray(config.globals)) {
+      for (const global of config.globals) {
+        if (merged.excludedGlobals.includes(global.slug)) {
+          continue
+        }
+        if (!hasDraftsEnabled(global)) {
+          continue
+        }
+        injectButton(global as unknown as Record<string, unknown>)
+      }
+    }
+
+    return config
+  }
+
+export default changesButtonPlugin

--- a/packages/changes-button/src/components/ChangesButton/index.tsx
+++ b/packages/changes-button/src/components/ChangesButton/index.tsx
@@ -1,0 +1,87 @@
+'use client'
+import {
+  Button,
+  useConfig,
+  useDocumentInfo,
+  useFormModified,
+  useModal,
+  useTranslation,
+} from '@payloadcms/ui'
+import { hasDraftsEnabled } from 'payload/shared'
+import React from 'react'
+
+import { getLabel } from '../../labels.js'
+import { useChangesDrawer } from '../ChangesDrawer'
+
+/**
+ * `ChangesButton` is the entry-point client component referenced from
+ * `config.admin.components.edit.beforeDocumentControls` (injected by
+ * `changesButtonPlugin`).
+ *
+ * Visibility rules — the button renders `null` unless ALL are true:
+ * - Entity has drafts enabled (`hasDraftsEnabled(entity)`).
+ * - User has publish permission (`useDocumentInfo().hasPublishPermission`).
+ * - Document is not in trash.
+ * - There are unpublished changes — either the form is `modified`
+ *   (in-progress unsaved edits) or `unpublishedVersionCount > 0` (saved
+ *   draft ahead of the published version). For brand-new entities (no
+ *   published baseline yet) the diff renders against an empty baseline so
+ *   the user can still review what would be published.
+ */
+export const ChangesButton: React.FC = () => {
+  const {
+    collectionSlug,
+    globalSlug,
+    hasPublishPermission,
+    id: docID,
+    isTrashed,
+    unpublishedVersionCount,
+  } = useDocumentInfo()
+  const modified = useFormModified()
+  const { getEntityConfig } = useConfig()
+  const { i18n } = useTranslation()
+
+  const entity = collectionSlug
+    ? getEntityConfig({ collectionSlug })
+    : globalSlug
+      ? getEntityConfig({ globalSlug })
+      : null
+
+  const draftsEnabled = entity ? hasDraftsEnabled(entity as Parameters<typeof hasDraftsEnabled>[0]) : false
+
+  const hasUnpublishedChanges = Boolean(modified) || (unpublishedVersionCount ?? 0) > 0
+
+  const visible =
+    draftsEnabled &&
+    Boolean(hasPublishPermission) &&
+    !isTrashed &&
+    hasUnpublishedChanges
+
+  const { Drawer: ChangesDrawerInstance, drawerSlug } = useChangesDrawer({
+    collectionSlug,
+    docID,
+    globalSlug,
+  })
+
+  const { openModal } = useModal()
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <React.Fragment>
+      <Button
+        buttonStyle="secondary"
+        className="changes-button"
+        onClick={() => openModal(drawerSlug)}
+        size="medium"
+      >
+        {getLabel('changes', i18n.language)}
+      </Button>
+      <ChangesDrawerInstance />
+    </React.Fragment>
+  )
+}
+
+export default ChangesButton

--- a/packages/changes-button/src/components/ChangesDrawer/CompareSourceToggle.tsx
+++ b/packages/changes-button/src/components/ChangesDrawer/CompareSourceToggle.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { useTranslation } from '@payloadcms/ui'
+import React from 'react'
+
+import type { CompareFrom } from '../../server/renderChangesDiff.js'
+
+import { getLabel } from '../../labels.js'
+
+export type CompareSourceToggleProps = {
+  availableSources: CompareFrom[]
+  onChange: (next: CompareFrom) => void
+  value: CompareFrom
+}
+
+/**
+ * Small segmented control switching between `'unsaved'` and `'latestDraft'`
+ * compare sources. Only renders when both sources are available.
+ */
+export const CompareSourceToggle: React.FC<CompareSourceToggleProps> = ({
+  availableSources,
+  onChange,
+  value,
+}) => {
+  const { i18n } = useTranslation()
+  if (availableSources.length < 2) {
+    return null
+  }
+  return (
+    <div className="changes-button__compare-toggle" role="tablist">
+      <button
+        aria-selected={value === 'unsaved'}
+        className={`changes-button__compare-toggle__option${
+          value === 'unsaved' ? ' changes-button__compare-toggle__option--active' : ''
+        }`}
+        onClick={() => onChange('unsaved')}
+        role="tab"
+        type="button"
+      >
+        {getLabel('toggleUnsaved', i18n.language)}
+      </button>
+      <button
+        aria-selected={value === 'latestDraft'}
+        className={`changes-button__compare-toggle__option${
+          value === 'latestDraft' ? ' changes-button__compare-toggle__option--active' : ''
+        }`}
+        onClick={() => onChange('latestDraft')}
+        role="tab"
+        type="button"
+      >
+        {getLabel('toggleLatestDraft', i18n.language)}
+      </button>
+    </div>
+  )
+}

--- a/packages/changes-button/src/components/ChangesDrawer/index.scss
+++ b/packages/changes-button/src/components/ChangesDrawer/index.scss
@@ -1,0 +1,38 @@
+.changes-button__drawer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base, 16px);
+  padding: var(--base, 16px) 0;
+}
+
+.changes-button__compare-toggle {
+  display: inline-flex;
+  border: 1px solid var(--theme-elevation-150, #ddd);
+  border-radius: 4px;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.changes-button__compare-toggle__option {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  padding: 6px 12px;
+}
+
+.changes-button__compare-toggle__option--active {
+  background: var(--theme-elevation-100, #eee);
+  font-weight: 600;
+}
+
+.changes-button__empty,
+.changes-button__error {
+  color: var(--theme-elevation-500, #666);
+  padding: 24px 0;
+  text-align: center;
+}
+
+.changes-button__error {
+  color: var(--theme-error-500, #b00020);
+}

--- a/packages/changes-button/src/components/ChangesDrawer/index.tsx
+++ b/packages/changes-button/src/components/ChangesDrawer/index.tsx
@@ -1,0 +1,159 @@
+'use client'
+import {
+  Drawer,
+  formatDrawerSlug,
+  LoadingOverlay,
+  useEditDepth,
+  useForm,
+  useFormModified,
+  useServerFunctions,
+  useTranslation,
+} from '@payloadcms/ui'
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
+
+import type { CompareFrom, RenderChangesDiffResult } from '../../server/renderChangesDiff.js'
+
+import { getLabel, SERVER_FUNCTION_KEY } from '../../labels.js'
+import { CompareSourceToggle } from './CompareSourceToggle.js'
+
+export type UseChangesDrawerArgs = {
+  collectionSlug?: string
+  docID?: number | string
+  globalSlug?: string
+}
+
+export type UseChangesDrawerReturn = {
+  closeDrawer: () => void
+  Drawer: React.FC
+  drawerSlug: string
+  openDrawer: () => void
+}
+
+/**
+ * Hook returning a stable drawer slug + a `<Drawer>` component bound to it.
+ *
+ * Mirrors the shape of `useVersionDrawer` from `@payloadcms/next` so call
+ * sites can swap implementations without restructuring. Stacking is handled
+ * by `useEditDepth()` so the drawer composes correctly inside relation-field
+ * drawers.
+ */
+export const useChangesDrawer = (args: UseChangesDrawerArgs): UseChangesDrawerReturn => {
+  const { i18n } = useTranslation()
+  const editDepth = useEditDepth()
+  const uuid = useId()
+  const drawerSlug = useMemo(
+    () => formatDrawerSlug({ slug: `changes-${uuid}`, depth: editDepth }),
+    [uuid, editDepth],
+  )
+
+  // The drawer JSX is exposed as a stable component so the caller can render it
+  // once near the toggler.
+  const DrawerComponent: React.FC = useCallback(
+    () => (
+      <Drawer
+        slug={drawerSlug}
+        title={getLabel('reviewChanges', i18n.language)}
+        children={<ChangesDrawerContent {...args} />}
+      />
+    ),
+    // We deliberately don't depend on `args` to avoid remounting the drawer on every render;
+    // identity-stable callers (memoized parents) get the same instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [drawerSlug, i18n.language],
+  )
+
+  // Open / close are no-ops here — wiring goes through `<DrawerToggler slug={drawerSlug}>`
+  // (faceless-ui handles the open state). The hook surface still exposes them so
+  // imperative callers can hook into the modal context themselves if needed.
+  return {
+    closeDrawer: () => undefined,
+    Drawer: DrawerComponent,
+    drawerSlug,
+    openDrawer: () => undefined,
+  }
+}
+
+type ChangesDrawerContentProps = UseChangesDrawerArgs
+
+const ChangesDrawerContent: React.FC<ChangesDrawerContentProps> = ({
+  collectionSlug,
+  docID,
+  globalSlug,
+}) => {
+  const { serverFunction } = useServerFunctions()
+  const modified = useFormModified()
+  const { getData } = useForm()
+  const { i18n } = useTranslation()
+
+  const initialCompareFrom: CompareFrom = modified ? 'unsaved' : 'latestDraft'
+  const [compareFrom, setCompareFrom] = useState<CompareFrom>(initialCompareFrom)
+  const [pending, setPending] = useState<boolean>(true)
+  const [error, setError] = useState<null | string>(null)
+  const [result, setResult] = useState<null | RenderChangesDiffResult>(null)
+
+  const fetchDiff = useCallback(
+    async (next: CompareFrom) => {
+      setPending(true)
+      setError(null)
+      try {
+        const formData = next === 'unsaved' ? (getData() as Record<string, unknown>) : undefined
+        const r = (await serverFunction({
+          name: SERVER_FUNCTION_KEY,
+          args: {
+            collectionSlug,
+            compareFrom: next,
+            docID,
+            formData,
+            globalSlug,
+          },
+        })) as RenderChangesDiffResult
+        setResult(r)
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[changes-button] failed to render diff', err)
+        setError(err instanceof Error ? err.message : getLabel('failedToLoadDiff', i18n.language))
+      } finally {
+        setPending(false)
+      }
+    },
+    [collectionSlug, docID, getData, globalSlug, serverFunction, i18n.language],
+  )
+
+  // Initial fetch on mount.
+  useEffect(() => {
+    void fetchDiff(initialCompareFrom)
+    // Run once on mount; subsequent updates flow through `handleToggle`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleToggle = useCallback(
+    (next: CompareFrom) => {
+      if (next === compareFrom) {
+        return
+      }
+      setCompareFrom(next)
+      void fetchDiff(next)
+    },
+    [compareFrom, fetchDiff],
+  )
+
+  return (
+    <div className="changes-button__drawer">
+      {result?.availableSources && modified ? (
+        <CompareSourceToggle
+          availableSources={result.availableSources}
+          onChange={handleToggle}
+          value={compareFrom}
+        />
+      ) : null}
+      {pending ? <LoadingOverlay /> : null}
+      {!pending && error ? <p className="changes-button__error">{error}</p> : null}
+      {!pending && !error && result?.hasChanges === false ? (
+        <p className="changes-button__empty">{getLabel('noChangesToReview', i18n.language)}</p>
+      ) : null}
+      {!pending && !error && result?.hasChanges ? (
+        <div className="changes-button__diff">{result.Diff}</div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/changes-button/src/index.client.tsx
+++ b/packages/changes-button/src/index.client.tsx
@@ -1,0 +1,13 @@
+'use client'
+/**
+ * Client entry — referenced by Payload's import map via the path
+ * `@shefing/changes-button/client#ChangesButton`. Keeping this barrel slim
+ * means the `react-server` boundary stays clear: nothing in this file or
+ * its transitive imports may run on the server.
+ */
+export { ChangesButton } from './components/ChangesButton/index.js'
+export { useChangesDrawer } from './components/ChangesDrawer/index.js'
+export type {
+  UseChangesDrawerArgs,
+  UseChangesDrawerReturn,
+} from './components/ChangesDrawer/index.js'

--- a/packages/changes-button/src/labels.ts
+++ b/packages/changes-button/src/labels.ts
@@ -1,0 +1,86 @@
+// Centralized labels for the changes-button plugin.
+// Mirrors the structure used by `@shefing/quickfilter` so that all labels are
+// declared in a single, locale-keyed object and consumed via `getLabel`.
+
+// List of locales for which translations are provided in this file.
+export const acceptedLanguages = ['ar', 'en', 'es', 'fr', 'he', 'zh'] as const;
+
+export const PLUGIN_LABELS = {
+  en: {
+    changes: 'Changes',
+    reviewChanges: 'Review changes',
+    noChangesToReview: 'No changes to review.',
+    failedToLoadDiff: 'Failed to load diff.',
+    toggleUnsaved: 'Unsaved',
+    toggleLatestDraft: 'Latest draft',
+  },
+  ar: {
+    changes: 'التغييرات',
+    reviewChanges: 'مراجعة التغييرات',
+    noChangesToReview: 'لا توجد تغييرات للمراجعة.',
+    failedToLoadDiff: 'فشل تحميل الفروق.',
+    toggleUnsaved: 'غير محفوظ',
+    toggleLatestDraft: 'أحدث مسودة',
+  },
+  fr: {
+    changes: 'Modifications',
+    reviewChanges: 'Examiner les modifications',
+    noChangesToReview: 'Aucune modification à examiner.',
+    failedToLoadDiff: 'Échec du chargement des différences.',
+    toggleUnsaved: 'Non enregistré',
+    toggleLatestDraft: 'Dernier brouillon',
+  },
+  es: {
+    changes: 'Cambios',
+    reviewChanges: 'Revisar cambios',
+    noChangesToReview: 'No hay cambios que revisar.',
+    failedToLoadDiff: 'Error al cargar las diferencias.',
+    toggleUnsaved: 'Sin guardar',
+    toggleLatestDraft: 'Último borrador',
+  },
+  zh: {
+    changes: '更改',
+    reviewChanges: '审核更改',
+    noChangesToReview: '没有需要审核的更改。',
+    failedToLoadDiff: '加载差异失败。',
+    toggleUnsaved: '未保存',
+    toggleLatestDraft: '最新草稿',
+  },
+  he: {
+    changes: 'שינויים',
+    reviewChanges: 'סקירת שינויים',
+    noChangesToReview: 'אין שינויים לסקירה.',
+    failedToLoadDiff: 'טעינת ההשוואה נכשלה.',
+    toggleUnsaved: 'לא נשמר',
+    toggleLatestDraft: 'טיוטה אחרונה',
+  },
+} as const;
+
+export type SupportedLocale = keyof typeof PLUGIN_LABELS;
+export type LabelKey = keyof typeof PLUGIN_LABELS.en;
+
+const isSupportedLocale = (l: string | undefined): l is SupportedLocale =>
+  !!l && (acceptedLanguages as readonly string[]).includes(l);
+
+// Helper function to get labels for a specific locale.
+export const getLabels = (locale: SupportedLocale = 'en') => {
+  return PLUGIN_LABELS[locale] || PLUGIN_LABELS.en;
+};
+
+// Helper function to get a specific label, falling back to English when the
+// requested locale or key is missing.
+export const getLabel = (key: LabelKey, locale: string | undefined = 'en'): string => {
+  const safeLocale: SupportedLocale = isSupportedLocale(locale) ? locale : 'en';
+  const labels = getLabels(safeLocale);
+  const value = labels[key as keyof typeof labels];
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  const fallback = PLUGIN_LABELS.en[key];
+  return typeof fallback === 'string' ? fallback : String(key);
+};
+
+/** Server-function key registered via the layout `wrapServerFunctions` helper. */
+export const SERVER_FUNCTION_KEY = 'shefing/changes-button:render-diff';

--- a/packages/changes-button/src/server/fetchVersions.ts
+++ b/packages/changes-button/src/server/fetchVersions.ts
@@ -1,0 +1,124 @@
+/**
+ * Slim wrapper around `payload.findVersions*` Local API helpers.
+ *
+ * This is intentionally a small, dependency-free copy of the same shape used
+ * inside `@payloadcms/next/views/Version/fetchVersions.ts`. It is duplicated
+ * here (rather than imported from a private path) so the plugin only depends
+ * on the public `payload` API surface.
+ */
+import {
+  logError,
+  type PaginatedDocs,
+  type PayloadRequest,
+  type SelectType,
+  type Sort,
+  type TypeWithVersion,
+  type Where,
+} from 'payload'
+
+export const fetchVersions = async <TVersionData extends object = object>({
+  collectionSlug,
+  depth,
+  globalSlug,
+  limit,
+  locale,
+  overrideAccess,
+  parentID,
+  req,
+  select,
+  sort,
+  where: whereFromArgs,
+}: {
+  collectionSlug?: string
+  depth?: number
+  globalSlug?: string
+  limit?: number
+  locale?: 'all' | ({} & string)
+  overrideAccess?: boolean
+  parentID?: number | string
+  req: PayloadRequest
+  select?: SelectType
+  sort?: Sort
+  where?: Where
+}): Promise<null | PaginatedDocs<TypeWithVersion<TVersionData>>> => {
+  const where: Where = { and: [...(whereFromArgs ? [whereFromArgs] : [])] }
+
+  try {
+    if (collectionSlug) {
+      if (parentID) {
+        where.and!.push({ parent: { equals: parentID } })
+      }
+      return (await req.payload.findVersions({
+        collection: collectionSlug,
+        depth,
+        draft: true,
+        limit,
+        locale,
+        overrideAccess,
+        req,
+        select,
+        sort,
+        where,
+      })) as PaginatedDocs<TypeWithVersion<TVersionData>>
+    } else if (globalSlug) {
+      return (await req.payload.findGlobalVersions({
+        slug: globalSlug,
+        depth,
+        limit,
+        locale,
+        overrideAccess,
+        req,
+        select,
+        sort,
+        where,
+      })) as PaginatedDocs<TypeWithVersion<TVersionData>>
+    }
+    return null
+  } catch (err) {
+    logError({ err, payload: req.payload })
+    return null
+  }
+}
+
+export const fetchLatestVersion = async <TVersionData extends object = object>({
+  collectionSlug,
+  globalSlug,
+  locale,
+  overrideAccess,
+  parentID,
+  req,
+  status,
+}: {
+  collectionSlug?: string
+  globalSlug?: string
+  locale?: 'all' | ({} & string)
+  overrideAccess?: boolean
+  parentID?: number | string
+  req: PayloadRequest
+  status: 'draft' | 'published'
+}): Promise<null | TypeWithVersion<TVersionData>> => {
+  const entityConfig = collectionSlug
+    ? req.payload.collections[collectionSlug]?.config
+    : globalSlug
+      ? req.payload.globals[globalSlug]?.config
+      : undefined
+  const draftsEnabled = entityConfig?.versions?.drafts
+  const and: Where[] = [
+    ...(draftsEnabled ? [{ 'version._status': { equals: status } as Where['version._status'] }] : []),
+  ]
+
+  const latest = await fetchVersions<TVersionData>({
+    collectionSlug,
+    depth: 1,
+    globalSlug,
+    limit: 1,
+    locale,
+    overrideAccess,
+    parentID,
+    req,
+    sort: '-updatedAt',
+    where: { and },
+  })
+
+  return latest?.docs?.length ? (latest.docs[0] as TypeWithVersion<TVersionData>) : null
+}

--- a/packages/changes-button/src/server/index.ts
+++ b/packages/changes-button/src/server/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Server entry — re-exports the server function for consumers who prefer
+ * manual wiring (e.g. registering it directly in `(payload)/layout.tsx`'s
+ * `extraServerFunctions` instead of relying on the plugin's auto-registration
+ * via `config.admin.serverFunctions`).
+ */
+export { renderChangesDiffHandler } from './renderChangesDiff.js'
+export type {
+  CompareFrom,
+  RenderChangesDiffArgs,
+  RenderChangesDiffResult,
+} from './renderChangesDiff.js'
+export { SERVER_FUNCTION_KEY } from '../labels.js'
+export { wrapHandleServerFunctions, wrapServerFunctions } from './wrapServerFunctions.js'

--- a/packages/changes-button/src/server/renderChangesDiff.test.ts
+++ b/packages/changes-button/src/server/renderChangesDiff.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `renderChangesDiff.test.ts` exercises the high-level branching of
+ * `renderChangesDiffHandler` without spinning up Payload.
+ *
+ * The vendored diff pipeline (`../vendor/diff/*`) and the schema-map utilities
+ * (`@payloadcms/ui/utilities/*`) are mocked — we are not testing those, only:
+ *
+ *   1. `hasChanges` is `false` when the from/to sibling data are identical.
+ *   2. `hasChanges` is `true` when they differ.
+ *   3. `compareFrom: 'unsaved'` requires `formData` and feeds it through.
+ *   4. Missing published baseline returns `{ hasChanges: false, Diff: null }`.
+ */
+
+// ---- Module mocks (must be at top, before importing the SUT) ----------------
+
+vi.mock('../vendor/diff/index.js', () => ({
+  RenderDiff: (args: { versionFromSiblingData: object; versionToSiblingData: object }) =>
+    ({ __diff: true, from: args.versionFromSiblingData, to: args.versionToSiblingData }) as unknown,
+}))
+vi.mock('../vendor/diff/utilities/countChangedFields.js', () => ({
+  countChangedFields: (args: { valueFrom?: object; valueTo?: object }) => {
+    const fromKeys = Object.keys(args.valueFrom ?? {})
+    const toKeys = Object.keys(args.valueTo ?? {})
+    const allKeys = new Set([...fromKeys, ...toKeys])
+    let count = 0
+    for (const k of allKeys) {
+      if (
+        (args.valueFrom as Record<string, unknown>)?.[k] !==
+        (args.valueTo as Record<string, unknown>)?.[k]
+      ) {
+        count += 1
+      }
+    }
+    return count
+  },
+}))
+vi.mock('@payloadcms/ui/utilities/getClientConfig', () => ({
+  getClientConfig: () => ({
+    collections: [{ slug: 'posts', fields: [{ name: 'title', type: 'text' }] }],
+    globals: [],
+  }),
+}))
+vi.mock('@payloadcms/ui/utilities/getClientSchemaMap', () => ({
+  getClientSchemaMap: () => new Map(),
+}))
+vi.mock('@payloadcms/ui/utilities/getSchemaMap', () => ({ getSchemaMap: () => new Map() }))
+
+// `fetchLatestVersion` is the only side-effecting helper inside the SUT — mock it
+// per-test to control the published / draft return values.
+const fetchLatestVersionMock = vi.fn()
+vi.mock('./fetchVersions.js', () => ({
+  fetchLatestVersion: (...args: unknown[]) => fetchLatestVersionMock(...args),
+  fetchVersions: vi.fn(),
+}))
+
+// ---- Helpers ----------------------------------------------------------------
+
+const makeReq = () =>
+  ({
+    headers: new Headers(),
+    i18n: {},
+    payload: {
+      auth: vi.fn(async () => ({
+        permissions: { collections: { posts: { fields: undefined } } },
+      })),
+      collections: { posts: { config: { fields: [{ name: 'title', type: 'text' }] } } },
+      config: { localization: undefined },
+      globals: {},
+      importMap: {},
+      logger: { error: vi.fn() },
+    },
+    user: undefined,
+  }) as unknown as Parameters<
+    Awaited<typeof import('./renderChangesDiff.js')>['renderChangesDiffHandler']
+  >[0]['req']
+
+beforeEach(() => {
+  fetchLatestVersionMock.mockReset()
+})
+
+describe('renderChangesDiffHandler', () => {
+  it('returns hasChanges: false when from/to sibling data are equal', async () => {
+    const { renderChangesDiffHandler } = await import('./renderChangesDiff.js')
+
+    fetchLatestVersionMock.mockImplementation(async ({ status }: { status: string }) => ({
+      version: { title: 'same' },
+      updatedAt: '2024-01-01T00:00:00Z',
+      __status: status,
+    }))
+
+    const result = await renderChangesDiffHandler({
+      collectionSlug: 'posts',
+      compareFrom: 'latestDraft',
+      req: makeReq(),
+    } as never)
+
+    expect(result.hasChanges).toBe(false)
+  })
+
+  it('returns hasChanges: true when sibling data differ', async () => {
+    const { renderChangesDiffHandler } = await import('./renderChangesDiff.js')
+
+    fetchLatestVersionMock.mockImplementation(async ({ status }: { status: string }) => ({
+      version: { title: status === 'published' ? 'old' : 'new' },
+      updatedAt: '2024-01-01T00:00:00Z',
+    }))
+
+    const result = await renderChangesDiffHandler({
+      collectionSlug: 'posts',
+      compareFrom: 'latestDraft',
+      req: makeReq(),
+    } as never)
+
+    expect(result.hasChanges).toBe(true)
+    expect(result.Diff).toBeTruthy()
+  })
+
+  it('throws when compareFrom === "unsaved" and no formData is supplied', async () => {
+    const { renderChangesDiffHandler } = await import('./renderChangesDiff.js')
+
+    fetchLatestVersionMock.mockResolvedValue({
+      version: { title: 'published' },
+      updatedAt: '2024-01-01T00:00:00Z',
+    })
+
+    await expect(
+      renderChangesDiffHandler({
+        collectionSlug: 'posts',
+        compareFrom: 'unsaved',
+        req: makeReq(),
+      } as never),
+    ).rejects.toThrow(/formData.*required.*unsaved/)
+  })
+
+  it('returns no-op result when there is no published baseline (latestDraft compare with no draft)', async () => {
+    const { renderChangesDiffHandler } = await import('./renderChangesDiff.js')
+
+    fetchLatestVersionMock.mockResolvedValue(null)
+
+    const result = await renderChangesDiffHandler({
+      collectionSlug: 'posts',
+      compareFrom: 'latestDraft',
+      req: makeReq(),
+    } as never)
+
+    expect(result.hasChanges).toBe(false)
+    expect(result.Diff).toBeNull()
+  })
+})

--- a/packages/changes-button/src/server/renderChangesDiff.tsx
+++ b/packages/changes-button/src/server/renderChangesDiff.tsx
@@ -1,0 +1,195 @@
+import type {
+  PayloadRequest,
+  SanitizedCollectionPermission,
+  SanitizedGlobalPermission,
+  ServerFunction,
+  TypeWithVersion,
+} from 'payload'
+import type { ReactNode } from 'react'
+
+// PR-A (`@payloadcms/next/views/diff` subpath export) is not yet in a Payload
+// release, so we vendor the diff pipeline locally under `../vendor/diff/`.
+// When PR-A lands, swap these three imports to `@payloadcms/next/views/diff`
+// and delete `src/vendor/diff/`.
+import { countChangedFields } from '../vendor/diff/utilities/countChangedFields.js'
+import { RenderDiff } from '../vendor/diff/index.js'
+import { getClientConfig } from '@payloadcms/ui/utilities/getClientConfig'
+import { getClientSchemaMap } from '@payloadcms/ui/utilities/getClientSchemaMap'
+import { getSchemaMap } from '@payloadcms/ui/utilities/getSchemaMap'
+
+import { fetchLatestVersion } from './fetchVersions.js'
+
+export type CompareFrom = 'latestDraft' | 'unsaved'
+
+export type RenderChangesDiffArgs = {
+  collectionSlug?: string
+  /** `'unsaved'` | `'latestDraft'`. Defaults to `'latestDraft'`. */
+  compareFrom?: CompareFrom
+  docID?: number | string
+  /** Required when `compareFrom === 'unsaved'`. */
+  formData?: Record<string, unknown>
+  globalSlug?: string
+  /** Optional locale code list; defaults to all configured locales. */
+  selectedLocales?: string[]
+}
+
+export type RenderChangesDiffResult = {
+  /** Sources that exist for this document; the client decides whether to show the toggle. */
+  availableSources: CompareFrom[]
+  /** Server-rendered React node containing the diff (empty when `hasChanges === false`). */
+  Diff: ReactNode
+  /** `true` when at least one field differs between from/to. */
+  hasChanges: boolean
+}
+
+/**
+ * `renderChangesDiffHandler` is a Payload Server Function (registered under the
+ * key `shefing/changes-button:render-diff`) that renders a diff between the
+ * currently-published version of a document and either the latest draft or
+ * the supplied unsaved form values.
+ *
+ * Reuses the same diff pipeline as the built-in Versions view via the public
+ * `@payloadcms/next/views/diff` subpath (PR-A).
+ */
+export const renderChangesDiffHandler: ServerFunction<
+  RenderChangesDiffArgs,
+  Promise<RenderChangesDiffResult>
+> = async ({ req, ...args }: RenderChangesDiffArgs & { req: PayloadRequest }): Promise<RenderChangesDiffResult> => {
+  const {
+    collectionSlug,
+    compareFrom = 'latestDraft',
+    formData,
+    globalSlug,
+    selectedLocales: selectedLocalesArg,
+  } = args
+
+  const { i18n, payload } = req
+  const { config } = payload
+  const { user } = req
+
+  const entityConfig = collectionSlug
+    ? payload.collections[collectionSlug]?.config
+    : globalSlug
+      ? payload.globals[globalSlug]?.config
+      : undefined
+
+  if (!entityConfig) {
+    throw new Error(
+      `[changes-button] Unknown entity: collectionSlug='${collectionSlug ?? ''}' globalSlug='${
+        globalSlug ?? ''
+      }'`,
+    )
+  }
+
+  // Resolve doc-level permissions for the diff (mirrors `Version/index.tsx`
+  // behavior, but uses the public `payload.auth` flow rather than the
+  // internal `initPageResult.permissions`).
+  const { permissions } = await payload.auth({ headers: req.headers, req })
+  const docPermissions: SanitizedCollectionPermission | SanitizedGlobalPermission | undefined =
+    collectionSlug ? permissions.collections?.[collectionSlug] : permissions.globals?.[globalSlug!]
+
+  // Fetch baseline (currently published) and — when needed — the latest draft.
+  const [currentlyPublishedVersion, latestDraftVersion] = await Promise.all([
+    fetchLatestVersion({ collectionSlug, globalSlug, locale: 'all', overrideAccess: false, req, status: 'published' }),
+    compareFrom === 'latestDraft'
+      ? fetchLatestVersion({ collectionSlug, globalSlug, locale: 'all', overrideAccess: false, req, status: 'draft' })
+      : Promise.resolve<null | TypeWithVersion<object>>(null),
+  ])
+
+  // The diff renders `versionFrom` on the LEFT (red, "before") and
+  // `versionTo` on the RIGHT (green, "after"). For the Review flow the user
+  // wants to see the currently published version on the left and the
+  // proposed/new content (unsaved edits or latest draft) on the right —
+  // i.e. "what is published" → "what will be published". For brand-new
+  // entities with no published baseline yet, `from` is an empty object so
+  // every field shows as an addition.
+  const versionFromSiblingData: object = currentlyPublishedVersion
+    ? {
+        ...(currentlyPublishedVersion.version as object),
+        updatedAt: currentlyPublishedVersion.updatedAt,
+      }
+    : {}
+
+  let versionToSiblingData: object
+  if (compareFrom === 'unsaved') {
+    if (!formData) {
+      throw new Error('[changes-button] `formData` is required when compareFrom === "unsaved".')
+    }
+    versionToSiblingData = formData
+  } else {
+    if (!latestDraftVersion) {
+      // Nothing to diff against — treat as no changes.
+      return { availableSources: ['unsaved'], Diff: null, hasChanges: false }
+    }
+    versionToSiblingData = {
+      ...(latestDraftVersion.version as object),
+      updatedAt: latestDraftVersion.updatedAt,
+    }
+  }
+
+  // Build the schema maps the diff pipeline expects.
+  const schemaMap = getSchemaMap({ collectionSlug, config, globalSlug, i18n })
+  const clientConfig = getClientConfig({ config, i18n, importMap: payload.importMap, user })
+  const clientSchemaMap = getClientSchemaMap({
+    collectionSlug,
+    config: clientConfig,
+    globalSlug,
+    i18n,
+    payload,
+    schemaMap,
+  })
+
+  // Resolve the top-level client fields for the entity (used by `countChangedFields`).
+  const clientFields = collectionSlug
+    ? clientConfig.collections?.find((c: { slug: string }) => c.slug === collectionSlug)?.fields
+    : clientConfig.globals?.find((g: { slug: string }) => g.slug === globalSlug)?.fields
+
+  // Default `selectedLocales` to all configured locales when unspecified.
+  const selectedLocales =
+    selectedLocalesArg ??
+    (config.localization ? config.localization.locales.map((l) => l.code) : [])
+
+  const buildArgs = {
+    clientSchemaMap,
+    customDiffComponents: {},
+    entitySlug: (collectionSlug || globalSlug)!,
+    fields: entityConfig.fields,
+    fieldsPermissions: docPermissions?.fields,
+    i18n,
+    modifiedOnly: true,
+    parentIndexPath: '',
+    parentIsLocalized: false,
+    parentPath: '',
+    parentSchemaPath: '',
+    req,
+    selectedLocales,
+    versionFromSiblingData,
+    versionToSiblingData,
+  } as const
+
+  const Diff = RenderDiff(buildArgs as Parameters<typeof RenderDiff>[0])
+
+  // Count changed fields between from/to siblings using the public API shape.
+  const hasChanges = clientFields
+    ? countChangedFields({
+        config: clientConfig,
+        fields: clientFields,
+        locales: selectedLocales.length > 0 ? selectedLocales : undefined,
+        parentIsLocalized: false,
+        valueFrom: versionFromSiblingData,
+        valueTo: versionToSiblingData,
+      } as Parameters<typeof countChangedFields>[0]) > 0
+    : false
+
+  const availableSources: CompareFrom[] = []
+  if (formData || compareFrom === 'unsaved') {
+    availableSources.push('unsaved')
+  }
+  if (latestDraftVersion) {
+    availableSources.push('latestDraft')
+  }
+
+  return { availableSources, Diff, hasChanges }
+}
+
+export default renderChangesDiffHandler

--- a/packages/changes-button/src/server/wrapServerFunctions.ts
+++ b/packages/changes-button/src/server/wrapServerFunctions.ts
@@ -1,0 +1,93 @@
+import type { ServerFunctionClient, ServerFunctionHandler } from 'payload'
+
+import { SERVER_FUNCTION_KEY } from '../labels.js'
+import { renderChangesDiffHandler } from './renderChangesDiff.js'
+
+/**
+ * Type of the per-call object Payload passes to a `ServerFunctionClient`.
+ * (Mirrors the shape `RootLayout` invokes the prop with — `name` + `args`.)
+ */
+type ServerFunctionClientArgs = Parameters<ServerFunctionClient>[0]
+
+/**
+ * Wrap the upstream `handleServerFunctions` so the `render-changes-diff` key
+ * is dispatched to this plugin's handler before falling through to the
+ * default Payload registry.
+ *
+ * Usage in `app/(payload)/layout.tsx`:
+ *
+ * ```ts
+ * import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
+ * import { wrapServerFunctions } from '@shefing/changes-button/server'
+ * import config from '@payload-config'
+ * import { importMap } from './admin/importMap.js'
+ *
+ * const baseServerFunction: ServerFunctionClient = async function (args) {
+ *   'use server'
+ *   return handleServerFunctions({ ...args, config, importMap })
+ * }
+ *
+ * const serverFunction = wrapServerFunctions(baseServerFunction)
+ *
+ * export default async function Layout({ children }) {
+ *   return (
+ *     <RootLayout config={config} importMap={importMap} serverFunction={serverFunction}>
+ *       {children}
+ *     </RootLayout>
+ *   )
+ * }
+ * ```
+ *
+ * This shim is only required until Payload PR-B
+ * (`config.admin.serverFunctions` registry) ships in a release; once it
+ * does, the plugin can self-register and this wrapper can be removed from
+ * `(payload)/layout.tsx`.
+ */
+export function wrapServerFunctions(
+  baseServerFunction: ServerFunctionClient,
+): ServerFunctionClient {
+  const wrapped = async function (args: ServerFunctionClientArgs) {
+    'use server'
+    if (args.name === SERVER_FUNCTION_KEY) {
+      // The plugin handler expects a `req`. The base `ServerFunctionClient`
+      // receives only `{ name, args }`; an upstream `handleServerFunctions`
+      // shim normally injects `req` for the resolved handler. We don't have
+      // direct access to `req` here, so we route the request through the
+      // base handler with a registry override that prepends our key to the
+      // built-in lookup.
+      return baseServerFunction({
+        ...args,
+        // `serverFunctions` is the registry the user can pass through to
+        // `handleServerFunctions` — Payload merges it before the built-ins.
+        serverFunctions: {
+          ...((args as ServerFunctionClientArgs & {
+            serverFunctions?: Record<string, unknown>
+          }).serverFunctions ?? {}),
+          [SERVER_FUNCTION_KEY]: renderChangesDiffHandler,
+        },
+      } as ServerFunctionClientArgs)
+    }
+    return baseServerFunction(args)
+  } as ServerFunctionClient
+  return wrapped
+}
+
+/**
+ * Lower-level helper for users who construct `handleServerFunctions` calls
+ * directly (no `ServerFunctionClient` wrapper). Returns a new handler that
+ * routes `render-changes-diff` to this plugin and forwards everything else
+ * to `base`.
+ */
+export function wrapHandleServerFunctions(
+  base: ServerFunctionHandler,
+): ServerFunctionHandler {
+  return async (args) => {
+    return base({
+      ...args,
+      serverFunctions: {
+        ...(args.serverFunctions ?? {}),
+        [SERVER_FUNCTION_KEY]: renderChangesDiffHandler,
+      },
+    })
+  }
+}

--- a/packages/changes-button/src/vendor/diff/DiffCollapser/index.scss
+++ b/packages/changes-button/src/vendor/diff/DiffCollapser/index.scss
@@ -1,0 +1,81 @@
+@import '~@payloadcms/ui/scss';
+
+@layer payload-default {
+  .diff-collapser {
+    &__toggle-button {
+      all: unset;
+      cursor: pointer;
+      position: relative;
+      z-index: 1;
+      display: flex;
+      align-items: center;
+
+      .icon {
+        color: var(--theme-elevation-500);
+      }
+
+      &:hover {
+        // Apply background color but with padding, thus we use after
+        &::before {
+          content: '';
+          position: absolute;
+          top: -(base(0.15));
+          left: -(base(0.15));
+          right: -(base(0.15));
+          bottom: -(base(0.15));
+          background-color: var(--theme-elevation-50);
+          border-radius: var(--style-radius-s);
+          z-index: -1;
+        }
+
+        .iterable-diff__label {
+          background-color: var(--theme-elevation-50);
+          z-index: 1;
+        }
+      }
+    }
+
+    &__label {
+      // Add space between label, chevron, and change count
+      margin: 0 calc(var(--base) * 0.3) 0 0;
+      display: inline-flex;
+      height: 100%;
+    }
+
+    &__field-change-count {
+      // Reset the font weight of the change count to normal
+      font-weight: normal;
+      margin-left: calc(var(--base) * 0.3);
+      padding: calc(var(--base) * 0.1) calc(var(--base) * 0.2);
+      background: var(--theme-elevation-100);
+      border-radius: var(--style-radius-s);
+      font-size: 0.8rem;
+    }
+
+    &__content:not(.diff-collapser__content--hide-gutter) {
+      [dir='ltr'] & {
+        // Vertical gutter
+        border-left: 2px solid var(--theme-elevation-100);
+        // Center-align the gutter with the chevron
+        margin-left: 3px;
+        // Content indentation
+        padding-left: calc(var(--base) * 0.5);
+      }
+      [dir='rtl'] & {
+        // Vertical gutter
+        border-right: 2px solid var(--theme-elevation-100);
+        // Center-align the gutter with the chevron
+        margin-right: 3px;
+        // Content indentation
+        padding-right: calc(var(--base) * 0.5);
+      }
+    }
+
+    &__content--is-collapsed {
+      // Hide the content when collapsed. We use display: none instead of
+      // conditional rendering to avoid loosing children's collapsed state when
+      // remounting.
+      display: none;
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/DiffCollapser/index.tsx
+++ b/packages/changes-button/src/vendor/diff/DiffCollapser/index.tsx
@@ -1,0 +1,122 @@
+'use client'
+import type { ClientField } from 'payload'
+
+import { ChevronIcon, FieldDiffLabel, useConfig, useTranslation } from '@payloadcms/ui'
+import { fieldIsArrayType, fieldIsBlockType } from 'payload/shared'
+import React, { useState } from 'react'
+
+import './index.scss'
+import { countChangedFields, countChangedFieldsInRows } from '../utilities/countChangedFields.js'
+
+const baseClass = 'diff-collapser'
+
+type Props = {
+  hideGutter?: boolean
+  initCollapsed?: boolean
+  Label: React.ReactNode
+  locales: string[] | undefined
+  parentIsLocalized: boolean
+  valueTo: unknown
+} & (
+  | {
+      // fields collapser
+      children: React.ReactNode
+      field?: never
+      fields: ClientField[]
+      isIterable?: false
+      valueFrom: unknown
+    }
+  | {
+      // iterable collapser
+      children: React.ReactNode
+      field: ClientField
+      fields?: never
+      isIterable: true
+      valueFrom?: unknown
+    }
+)
+
+export const DiffCollapser: React.FC<Props> = ({
+  children,
+  field,
+  fields,
+  hideGutter = false,
+  initCollapsed = false,
+  isIterable = false,
+  Label,
+  locales,
+  parentIsLocalized,
+  valueFrom,
+  valueTo,
+}) => {
+  const { t } = useTranslation()
+  const [isCollapsed, setIsCollapsed] = useState(initCollapsed)
+  const { config } = useConfig()
+
+  let changeCount = 0
+
+  if (isIterable) {
+    if (!fieldIsArrayType(field) && !fieldIsBlockType(field)) {
+      throw new Error(
+        'DiffCollapser: field must be an array or blocks field when isIterable is true',
+      )
+    }
+    const valueFromRows = valueFrom ?? []
+    const valueToRows = valueTo ?? []
+
+    if (!Array.isArray(valueFromRows) || !Array.isArray(valueToRows)) {
+      throw new Error(
+        'DiffCollapser: valueFrom and valueTro must be arrays when isIterable is true',
+      )
+    }
+
+    changeCount = countChangedFieldsInRows({
+      config,
+      field,
+      locales,
+      parentIsLocalized,
+      valueFromRows,
+      valueToRows,
+    })
+  } else {
+    changeCount = countChangedFields({
+      config,
+      fields,
+      locales,
+      parentIsLocalized,
+      valueFrom,
+      valueTo,
+    })
+  }
+
+  const contentClassNames = [
+    `${baseClass}__content`,
+    isCollapsed && `${baseClass}__content--is-collapsed`,
+    hideGutter && `${baseClass}__content--hide-gutter`,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={baseClass}>
+      <FieldDiffLabel>
+        <button
+          aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+          className={`${baseClass}__toggle-button`}
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          type="button"
+        >
+          <div className={`${baseClass}__label`}>{Label}</div>
+
+          <ChevronIcon direction={isCollapsed ? 'right' : 'down'} size={'small'} />
+        </button>
+        {changeCount > 0 && isCollapsed && (
+          <span className={`${baseClass}__field-change-count`}>
+            {t('version:changedFieldsCount', { count: changeCount })}
+          </span>
+        )}
+      </FieldDiffLabel>
+      <div className={contentClassNames}>{children}</div>
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/RenderVersionFieldsToDiff.tsx
+++ b/packages/changes-button/src/vendor/diff/RenderVersionFieldsToDiff.tsx
@@ -1,0 +1,73 @@
+'use client'
+const baseClass = 'render-field-diffs'
+import type { VersionField } from 'payload'
+
+import './index.scss'
+
+import { ShimmerEffect } from '@payloadcms/ui'
+import React, { Fragment, useEffect } from 'react'
+
+export const RenderVersionFieldsToDiff = ({
+  parent = false,
+  versionFields,
+}: {
+  /**
+   * If true, this is the parent render version fields component, not one nested in
+   * a field with children (e.g. group)
+   */
+  parent?: boolean
+  versionFields: VersionField[]
+}): React.ReactNode => {
+  const [hasMounted, setHasMounted] = React.useState(false)
+
+  // defer rendering until after the first mount as the CSS is loaded with Emotion
+  // this will ensure that the CSS is loaded before rendering the diffs and prevent CLS
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  return (
+    <div className={`${baseClass}${parent ? ` ${baseClass}--parent` : ''}`}>
+      {!hasMounted ? (
+        <Fragment>
+          <ShimmerEffect height="8rem" width="100%" />
+        </Fragment>
+      ) : (
+        versionFields?.map((field, fieldIndex) => {
+          if (field.fieldByLocale) {
+            const LocaleComponents: React.ReactNode[] = []
+            for (const [locale, baseField] of Object.entries(field.fieldByLocale)) {
+              LocaleComponents.push(
+                <div
+                  className={`${baseClass}__locale`}
+                  data-field-path={baseField.path}
+                  data-locale={locale}
+                  key={[locale, fieldIndex].join('-')}
+                >
+                  <div className={`${baseClass}__locale-value`}>{baseField.CustomComponent}</div>
+                </div>,
+              )
+            }
+            return (
+              <div className={`${baseClass}__field`} key={fieldIndex}>
+                {LocaleComponents}
+              </div>
+            )
+          } else if (field.field) {
+            return (
+              <div
+                className={`${baseClass}__field field__${field.field.type}`}
+                data-field-path={field.field.path}
+                key={fieldIndex}
+              >
+                {field.field.CustomComponent}
+              </div>
+            )
+          }
+
+          return null
+        })
+      )}
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/SelectedLocalesContext.tsx
+++ b/packages/changes-button/src/vendor/diff/SelectedLocalesContext.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { createContext, use } from 'react'
+
+type SelectedLocalesContextType = {
+  selectedLocales: string[]
+}
+
+export const SelectedLocalesContext = createContext<SelectedLocalesContextType>({
+  selectedLocales: [],
+})
+
+export const useSelectedLocales = () => use(SelectedLocalesContext)

--- a/packages/changes-button/src/vendor/diff/buildVersionFields.tsx
+++ b/packages/changes-button/src/vendor/diff/buildVersionFields.tsx
@@ -1,0 +1,565 @@
+import type { I18nClient } from '@payloadcms/translations'
+
+import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
+import { dequal } from 'dequal/lite'
+import {
+  type BaseVersionField,
+  type ClientField,
+  type ClientFieldSchemaMap,
+  type Field,
+  type FieldDiffClientProps,
+  type FieldDiffServerProps,
+  type FieldTypes,
+  type FlattenedBlock,
+  MissingEditorProp,
+  type PayloadComponent,
+  type PayloadRequest,
+  type SanitizedFieldPermissions,
+  type SanitizedFieldsPermissions,
+  type VersionField,
+} from 'payload'
+import {
+  fieldIsID,
+  fieldShouldBeLocalized,
+  getFieldPaths,
+  getUniqueListBy,
+  tabHasName,
+} from 'payload/shared'
+
+import { diffComponents } from './fields/index.js'
+
+export type BuildVersionFieldsArgs = {
+  clientSchemaMap: ClientFieldSchemaMap
+  customDiffComponents: Partial<
+    Record<FieldTypes, PayloadComponent<FieldDiffServerProps, FieldDiffClientProps>>
+  >
+  entitySlug: string
+  fields: Field[]
+  fieldsPermissions: SanitizedFieldsPermissions
+  i18n: I18nClient
+  modifiedOnly: boolean
+  nestingLevel?: number
+  parentIndexPath: string
+  parentIsLocalized: boolean
+  parentPath: string
+  parentSchemaPath: string
+  req: PayloadRequest
+  selectedLocales: string[]
+  versionFromSiblingData: object
+  versionToSiblingData: object
+}
+
+/**
+ * Build up an object that contains rendered diff components for each field.
+ * This is then sent to the client to be rendered.
+ *
+ * Here, the server is responsible for traversing through the document data and building up this
+ * version state object.
+ */
+export const buildVersionFields = ({
+  clientSchemaMap,
+  customDiffComponents,
+  entitySlug,
+  fields,
+  fieldsPermissions,
+  i18n,
+  modifiedOnly,
+  nestingLevel = 0,
+  parentIndexPath,
+  parentIsLocalized,
+  parentPath,
+  parentSchemaPath,
+  req,
+  selectedLocales,
+  versionFromSiblingData,
+  versionToSiblingData,
+}: BuildVersionFieldsArgs): {
+  versionFields: VersionField[]
+} => {
+  const versionFields: VersionField[] = []
+  let fieldIndex = -1
+
+  for (const field of fields) {
+    fieldIndex++
+
+    if (fieldIsID(field)) {
+      continue
+    }
+
+    const { indexPath, path, schemaPath } = getFieldPaths({
+      field,
+      index: fieldIndex,
+      parentIndexPath,
+      parentPath,
+      parentSchemaPath,
+    })
+
+    const clientField = clientSchemaMap.get(entitySlug + '.' + schemaPath)
+
+    if (!clientField) {
+      req.payload.logger.error({
+        clientFieldKey: entitySlug + '.' + schemaPath,
+        clientSchemaMapKeys: Array.from(clientSchemaMap.keys()),
+        msg: 'No client field found for ' + entitySlug + '.' + schemaPath,
+        parentPath,
+        parentSchemaPath,
+        path,
+        schemaPath,
+      })
+      throw new Error('No client field found for ' + entitySlug + '.' + schemaPath)
+    }
+
+    const versionField: VersionField = {}
+    const isLocalized = fieldShouldBeLocalized({ field, parentIsLocalized })
+
+    const fieldName: null | string = 'name' in field ? field.name : null
+
+    const valueFrom = fieldName ? versionFromSiblingData?.[fieldName] : versionFromSiblingData
+    const valueTo = fieldName ? versionToSiblingData?.[fieldName] : versionToSiblingData
+
+    if (isLocalized) {
+      versionField.fieldByLocale = {}
+
+      for (const locale of selectedLocales) {
+        const localizedVersionField = buildVersionField({
+          clientField: clientField as ClientField,
+          clientSchemaMap,
+          customDiffComponents,
+          entitySlug,
+          field,
+          i18n,
+          indexPath,
+          locale,
+          modifiedOnly,
+          nestingLevel,
+          parentFieldsPermissions: fieldsPermissions,
+          parentIsLocalized: true,
+          parentPath,
+          parentSchemaPath,
+          path,
+          req,
+          schemaPath,
+          selectedLocales,
+          valueFrom: valueFrom?.[locale],
+          valueTo: valueTo?.[locale],
+        })
+        if (localizedVersionField) {
+          versionField.fieldByLocale[locale] = localizedVersionField
+        }
+      }
+    } else {
+      const baseVersionField = buildVersionField({
+        clientField: clientField as ClientField,
+        clientSchemaMap,
+        customDiffComponents,
+        entitySlug,
+        field,
+        i18n,
+        indexPath,
+        modifiedOnly,
+        nestingLevel,
+        parentFieldsPermissions: fieldsPermissions,
+        parentIsLocalized: parentIsLocalized || ('localized' in field && field.localized),
+        parentPath,
+        parentSchemaPath,
+        path,
+        req,
+        schemaPath,
+        selectedLocales,
+        valueFrom,
+        valueTo,
+      })
+
+      if (baseVersionField) {
+        versionField.field = baseVersionField
+      }
+    }
+
+    if (
+      versionField.field ||
+      (versionField.fieldByLocale && Object.keys(versionField.fieldByLocale).length)
+    ) {
+      versionFields.push(versionField)
+    }
+  }
+
+  return {
+    versionFields,
+  }
+}
+
+const buildVersionField = ({
+  clientField,
+  clientSchemaMap,
+  customDiffComponents,
+  entitySlug,
+  field,
+  i18n,
+  indexPath,
+  locale,
+  modifiedOnly,
+  nestingLevel,
+  parentFieldsPermissions,
+  parentIsLocalized,
+  parentPath,
+  parentSchemaPath,
+  path,
+  req,
+  schemaPath,
+  selectedLocales,
+  valueFrom,
+  valueTo,
+}: {
+  clientField: ClientField
+  field: Field
+  indexPath: string
+  locale?: string
+  modifiedOnly?: boolean
+  nestingLevel: number
+  parentFieldsPermissions: SanitizedFieldsPermissions
+  parentIsLocalized: boolean
+  path: string
+  schemaPath: string
+  valueFrom: unknown
+  valueTo: unknown
+} & Omit<
+  BuildVersionFieldsArgs,
+  | 'fields'
+  | 'fieldsPermissions'
+  | 'parentIndexPath'
+  | 'versionFromSiblingData'
+  | 'versionToSiblingData'
+>): BaseVersionField | null => {
+  let hasReadPermission: boolean = false
+  let fieldPermissions: SanitizedFieldPermissions | undefined = undefined
+
+  if (typeof parentFieldsPermissions === 'boolean') {
+    hasReadPermission = parentFieldsPermissions
+    fieldPermissions = parentFieldsPermissions
+  } else {
+    if ('name' in field) {
+      fieldPermissions = parentFieldsPermissions?.[field.name]
+      if (typeof fieldPermissions === 'boolean') {
+        hasReadPermission = fieldPermissions
+      } else if (typeof fieldPermissions?.read === 'boolean') {
+        hasReadPermission = fieldPermissions.read
+      }
+    } else {
+      // If the field is unnamed and parentFieldsPermissions is an object, its sub-fields will decide their read permissions state.
+      // As far as this field is concerned, we are allowed to read it, as we need to reach its sub-fields to determine their read permissions.
+      hasReadPermission = true
+    }
+  }
+
+  if (!hasReadPermission) {
+    // HasReadPermission is only valid if the field has a name. E.g. for a tabs field it would incorrectly return `false`.
+    return null
+  }
+
+  if (modifiedOnly && dequal(valueFrom, valueTo)) {
+    return null
+  }
+
+  let CustomComponent = customDiffComponents?.[field.type]
+  if (field?.type === 'richText') {
+    if (!field?.editor) {
+      throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+    }
+
+    if (typeof field?.editor === 'function') {
+      throw new Error('Attempted to access unsanitized rich text editor.')
+    }
+
+    if (field.editor.CellComponent) {
+      CustomComponent = field.editor.DiffComponent
+    }
+  }
+  if (field?.admin?.components?.Diff) {
+    CustomComponent = field.admin.components.Diff
+  }
+
+  const DefaultComponent = diffComponents?.[field.type]
+
+  const baseVersionField: BaseVersionField = {
+    type: field.type,
+    fields: [],
+    path,
+    schemaPath,
+  }
+
+  if (field.type === 'tabs' && 'tabs' in field) {
+    baseVersionField.tabs = []
+    let tabIndex = -1
+    for (const tab of field.tabs) {
+      tabIndex++
+      const isNamedTab = tabHasName(tab)
+
+      const tabAsField = { ...tab, type: 'tab' }
+
+      const {
+        indexPath: tabIndexPath,
+        path: tabPath,
+        schemaPath: tabSchemaPath,
+      } = getFieldPaths({
+        field: tabAsField,
+        index: tabIndex,
+        parentIndexPath: indexPath,
+        parentPath: path,
+        parentSchemaPath: schemaPath,
+      })
+
+      let tabFieldsPermissions: SanitizedFieldsPermissions = undefined
+
+      // The tabs field does not have its own permissions as it's unnamed => use parentFieldsPermissions
+      if (typeof parentFieldsPermissions === 'boolean') {
+        tabFieldsPermissions = parentFieldsPermissions
+      } else {
+        if ('name' in tab) {
+          const tabPermissions = parentFieldsPermissions?.[tab.name]
+          if (typeof tabPermissions === 'boolean') {
+            tabFieldsPermissions = tabPermissions
+          } else {
+            tabFieldsPermissions = tabPermissions?.fields
+          }
+        } else {
+          tabFieldsPermissions = parentFieldsPermissions
+        }
+      }
+
+      const tabVersion = {
+        name: 'name' in tab ? tab.name : null,
+        fields: buildVersionFields({
+          clientSchemaMap,
+          customDiffComponents,
+          entitySlug,
+          fields: tab.fields,
+          fieldsPermissions: tabFieldsPermissions,
+          i18n,
+          modifiedOnly,
+          nestingLevel: nestingLevel + 1,
+          parentIndexPath: isNamedTab ? '' : tabIndexPath,
+          parentIsLocalized: parentIsLocalized || tab.localized,
+          parentPath: isNamedTab ? tabPath : 'name' in field ? path : parentPath,
+          parentSchemaPath: tabSchemaPath,
+          req,
+          selectedLocales,
+          versionFromSiblingData: 'name' in tab ? valueFrom?.[tab.name] : valueFrom,
+          versionToSiblingData: 'name' in tab ? valueTo?.[tab.name] : valueTo,
+        }).versionFields,
+        label: typeof tab.label === 'function' ? tab.label({ i18n, t: i18n.t }) : tab.label,
+      }
+      if (tabVersion?.fields?.length) {
+        baseVersionField.tabs.push(tabVersion)
+      }
+    }
+
+    if (modifiedOnly && !baseVersionField.tabs.length) {
+      return null
+    }
+  } // At this point, we are dealing with a `row`, `collapsible`, array`, etc
+  else if ('fields' in field) {
+    let subFieldsPermissions: SanitizedFieldsPermissions = undefined
+
+    if ('name' in field && typeof fieldPermissions !== 'undefined') {
+      // Named fields like arrays
+      subFieldsPermissions =
+        typeof fieldPermissions === 'boolean' ? fieldPermissions : fieldPermissions.fields
+    } else {
+      // Unnamed fields like collapsible and row inherit directly from parent permissions
+      subFieldsPermissions = parentFieldsPermissions
+    }
+
+    if (field.type === 'array' && (valueTo || valueFrom)) {
+      const maxLength = Math.max(
+        Array.isArray(valueTo) ? valueTo.length : 0,
+        Array.isArray(valueFrom) ? valueFrom.length : 0,
+      )
+      baseVersionField.rows = []
+
+      for (let i = 0; i < maxLength; i++) {
+        const fromRow = (Array.isArray(valueFrom) && valueFrom?.[i]) || {}
+        const toRow = (Array.isArray(valueTo) && valueTo?.[i]) || {}
+
+        const versionFields = buildVersionFields({
+          clientSchemaMap,
+          customDiffComponents,
+          entitySlug,
+          fields: field.fields,
+          fieldsPermissions: subFieldsPermissions,
+          i18n,
+          modifiedOnly,
+          nestingLevel: nestingLevel + 1,
+          parentIndexPath: 'name' in field ? '' : indexPath,
+          parentIsLocalized: parentIsLocalized || field.localized,
+          parentPath: ('name' in field ? path : parentPath) + '.' + i,
+          parentSchemaPath: schemaPath,
+          req,
+          selectedLocales,
+          versionFromSiblingData: fromRow,
+          versionToSiblingData: toRow,
+        }).versionFields
+
+        if (versionFields?.length) {
+          baseVersionField.rows[i] = versionFields
+        }
+      }
+
+      if (!baseVersionField.rows?.length && modifiedOnly) {
+        return null
+      }
+    } else {
+      baseVersionField.fields = buildVersionFields({
+        clientSchemaMap,
+        customDiffComponents,
+        entitySlug,
+        fields: field.fields,
+        fieldsPermissions: subFieldsPermissions,
+        i18n,
+        modifiedOnly,
+        nestingLevel: field.type !== 'row' ? nestingLevel + 1 : nestingLevel,
+        parentIndexPath: 'name' in field ? '' : indexPath,
+        parentIsLocalized: parentIsLocalized || ('localized' in field && field.localized),
+        parentPath: 'name' in field ? path : parentPath,
+        parentSchemaPath: schemaPath,
+        req,
+        selectedLocales,
+        versionFromSiblingData: valueFrom as object,
+        versionToSiblingData: valueTo as object,
+      }).versionFields
+
+      if (modifiedOnly && !baseVersionField.fields?.length) {
+        return null
+      }
+    }
+  } else if (field.type === 'blocks') {
+    baseVersionField.rows = []
+
+    const maxLength = Math.max(
+      Array.isArray(valueTo) ? valueTo.length : 0,
+      Array.isArray(valueFrom) ? valueFrom.length : 0,
+    )
+
+    for (let i = 0; i < maxLength; i++) {
+      const fromRow = (Array.isArray(valueFrom) && valueFrom?.[i]) || {}
+      const toRow = (Array.isArray(valueTo) && valueTo?.[i]) || {}
+
+      const blockSlugToMatch: string = toRow?.blockType ?? fromRow?.blockType
+      const toBlock =
+        req.payload.blocks[blockSlugToMatch] ??
+        ((field.blockReferences ?? field.blocks).find(
+          (block) => typeof block !== 'string' && block.slug === blockSlugToMatch,
+        ) as FlattenedBlock | undefined)
+
+      let fields = []
+
+      if (toRow.blockType === fromRow.blockType) {
+        fields = toBlock.fields
+      } else {
+        const fromBlockSlugToMatch: string = toRow?.blockType ?? fromRow?.blockType
+
+        const fromBlock =
+          req.payload.blocks[fromBlockSlugToMatch] ??
+          ((field.blockReferences ?? field.blocks).find(
+            (block) => typeof block !== 'string' && block.slug === fromBlockSlugToMatch,
+          ) as FlattenedBlock | undefined)
+
+        if (fromBlock) {
+          fields = getUniqueListBy<Field>([...toBlock.fields, ...fromBlock.fields], 'name')
+        } else {
+          fields = toBlock.fields
+        }
+      }
+
+      let blockFieldsPermissions: SanitizedFieldsPermissions = undefined
+
+      // fieldPermissions will be set here, as the blocks field has a name
+      if (typeof fieldPermissions === 'boolean') {
+        blockFieldsPermissions = fieldPermissions
+      } else if (typeof fieldPermissions?.blocks === 'boolean') {
+        blockFieldsPermissions = fieldPermissions.blocks
+      } else {
+        const permissionsBlockSpecific = fieldPermissions?.blocks?.[blockSlugToMatch]
+        if (typeof permissionsBlockSpecific === 'boolean') {
+          blockFieldsPermissions = permissionsBlockSpecific
+        } else {
+          blockFieldsPermissions = permissionsBlockSpecific?.fields
+        }
+      }
+
+      const versionFields = buildVersionFields({
+        clientSchemaMap,
+        customDiffComponents,
+        entitySlug,
+        fields,
+        fieldsPermissions: blockFieldsPermissions,
+        i18n,
+        modifiedOnly,
+        nestingLevel: nestingLevel + 1,
+        parentIndexPath: 'name' in field ? '' : indexPath,
+        parentIsLocalized: parentIsLocalized || ('localized' in field && field.localized),
+        parentPath: ('name' in field ? path : parentPath) + '.' + i,
+        parentSchemaPath: schemaPath + '.' + toBlock.slug,
+        req,
+        selectedLocales,
+        versionFromSiblingData: fromRow,
+        versionToSiblingData: toRow,
+      }).versionFields
+
+      if (versionFields?.length) {
+        baseVersionField.rows[i] = versionFields
+      }
+    }
+
+    if (!baseVersionField.rows?.length && modifiedOnly) {
+      return null
+    }
+  }
+
+  const clientDiffProps: FieldDiffClientProps = {
+    baseVersionField: {
+      ...baseVersionField,
+      CustomComponent: undefined,
+    },
+    /**
+     * TODO: Change to valueFrom in 4.0
+     */
+    comparisonValue: valueFrom,
+    /**
+     * @deprecated remove in 4.0. Each field should handle its own diffing logic
+     */
+    diffMethod: 'diffWordsWithSpace',
+    field: clientField,
+    fieldPermissions:
+      typeof fieldPermissions === 'undefined' ? parentFieldsPermissions : fieldPermissions,
+    parentIsLocalized,
+
+    nestingLevel: nestingLevel ? nestingLevel : undefined,
+    /**
+     * TODO: Change to valueTo in 4.0
+     */
+    versionValue: valueTo,
+  }
+  if (locale) {
+    clientDiffProps.locale = locale
+  }
+
+  const serverDiffProps: FieldDiffServerProps = {
+    ...clientDiffProps,
+    clientField,
+    field,
+    i18n,
+    req,
+    selectedLocales,
+  }
+
+  baseVersionField.CustomComponent = RenderServerComponent({
+    clientProps: clientDiffProps,
+    Component: CustomComponent,
+    Fallback: DefaultComponent,
+    importMap: req.payload.importMap,
+    key: 'diff component',
+    serverProps: serverDiffProps,
+  })
+
+  return baseVersionField
+}

--- a/packages/changes-button/src/vendor/diff/fields/Collapsible/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Collapsible/index.tsx
@@ -1,0 +1,46 @@
+'use client'
+import type { CollapsibleFieldDiffClientComponent } from 'payload'
+
+import { getTranslation } from '@payloadcms/translations'
+import { useTranslation } from '@payloadcms/ui'
+import React from 'react'
+
+import { useSelectedLocales } from '../../SelectedLocalesContext.js'
+import { DiffCollapser } from '../../DiffCollapser/index.js'
+import { RenderVersionFieldsToDiff } from '../../RenderVersionFieldsToDiff.js'
+
+const baseClass = 'collapsible-diff'
+
+export const Collapsible: CollapsibleFieldDiffClientComponent = ({
+  baseVersionField,
+  comparisonValue: valueFrom,
+  field,
+  parentIsLocalized,
+  versionValue: valueTo,
+}) => {
+  const { i18n } = useTranslation()
+  const { selectedLocales } = useSelectedLocales()
+
+  if (!baseVersionField.fields?.length) {
+    return null
+  }
+
+  return (
+    <div className={baseClass}>
+      <DiffCollapser
+        fields={field.fields}
+        Label={
+          'label' in field &&
+          field.label &&
+          typeof field.label !== 'function' && <span>{getTranslation(field.label, i18n)}</span>
+        }
+        locales={selectedLocales}
+        parentIsLocalized={parentIsLocalized || field.localized}
+        valueFrom={valueFrom}
+        valueTo={valueTo}
+      >
+        <RenderVersionFieldsToDiff versionFields={baseVersionField.fields} />
+      </DiffCollapser>
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Date/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Date/index.scss
@@ -1,0 +1,12 @@
+@layer payload-default {
+  .date-diff {
+    p *[data-match-type='delete'] {
+      color: unset !important;
+      background-color: unset !important;
+    }
+    p *[data-match-type='create'] {
+      color: unset !important;
+      background-color: unset !important;
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Date/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Date/index.tsx
@@ -1,0 +1,78 @@
+'use client'
+import type { DateFieldDiffClientComponent } from 'payload'
+
+import {
+  escapeDiffHTML,
+  FieldDiffContainer,
+  getHTMLDiffComponents,
+  unescapeDiffHTML,
+  useConfig,
+  useTranslation,
+} from '@payloadcms/ui'
+import { formatDate } from '@payloadcms/ui/shared'
+import React from 'react'
+
+import './index.scss'
+
+const baseClass = 'date-diff'
+
+export const DateDiffComponent: DateFieldDiffClientComponent = ({
+  comparisonValue: valueFrom,
+  field,
+  locale,
+  nestingLevel,
+  versionValue: valueTo,
+}) => {
+  const { i18n } = useTranslation()
+  const {
+    config: {
+      admin: { dateFormat },
+    },
+  } = useConfig()
+
+  const formattedFromDate = valueFrom
+    ? formatDate({
+        date: typeof valueFrom === 'string' ? new Date(valueFrom) : (valueFrom as Date),
+        i18n,
+        pattern: dateFormat,
+      })
+    : ''
+
+  const formattedToDate = valueTo
+    ? formatDate({
+        date: typeof valueTo === 'string' ? new Date(valueTo) : (valueTo as Date),
+        i18n,
+        pattern: dateFormat,
+      })
+    : ''
+
+  const escapedFromDate = escapeDiffHTML(formattedFromDate)
+  const escapedToDate = escapeDiffHTML(formattedToDate)
+
+  const { From, To } = getHTMLDiffComponents({
+    fromHTML:
+      `<div class="${baseClass}" data-enable-match="true" data-date="${escapedFromDate}"><p>` +
+      escapedFromDate +
+      '</p></div>',
+    postProcess: unescapeDiffHTML,
+    toHTML:
+      `<div class="${baseClass}" data-enable-match="true" data-date="${escapedToDate}"><p>` +
+      escapedToDate +
+      '</p></div>',
+    tokenizeByCharacter: false,
+  })
+
+  return (
+    <FieldDiffContainer
+      className={baseClass}
+      From={From}
+      i18n={i18n}
+      label={{
+        label: field.label,
+        locale,
+      }}
+      nestingLevel={nestingLevel}
+      To={To}
+    />
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Group/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Group/index.scss
@@ -1,0 +1,9 @@
+@layer payload-default {
+  .group-diff {
+    &__locale-label {
+      &--no-label {
+        color: var(--theme-elevation-600);
+      }
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Group/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Group/index.tsx
@@ -1,0 +1,53 @@
+'use client'
+import type { GroupFieldDiffClientComponent } from 'payload'
+
+import { getTranslation } from '@payloadcms/translations'
+
+import './index.scss'
+
+import { useTranslation } from '@payloadcms/ui'
+import React from 'react'
+
+import { useSelectedLocales } from '../../SelectedLocalesContext.js'
+import { DiffCollapser } from '../../DiffCollapser/index.js'
+import { RenderVersionFieldsToDiff } from '../../RenderVersionFieldsToDiff.js'
+
+const baseClass = 'group-diff'
+
+export const Group: GroupFieldDiffClientComponent = ({
+  baseVersionField,
+  comparisonValue: valueFrom,
+  field,
+  locale,
+  parentIsLocalized,
+  versionValue: valueTo,
+}) => {
+  const { i18n } = useTranslation()
+  const { selectedLocales } = useSelectedLocales()
+
+  return (
+    <div className={baseClass}>
+      <DiffCollapser
+        fields={field.fields}
+        Label={
+          'label' in field && field.label && typeof field.label !== 'function' ? (
+            <span>
+              {locale && <span className={`${baseClass}__locale-label`}>{locale}</span>}
+              {getTranslation(field.label, i18n)}
+            </span>
+          ) : (
+            <span className={`${baseClass}__locale-label ${baseClass}__locale-label--no-label`}>
+              &lt;{i18n.t('version:noLabelGroup')}&gt;
+            </span>
+          )
+        }
+        locales={selectedLocales}
+        parentIsLocalized={parentIsLocalized || field.localized}
+        valueFrom={valueFrom}
+        valueTo={valueTo}
+      >
+        <RenderVersionFieldsToDiff versionFields={baseVersionField.fields} />
+      </DiffCollapser>
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Iterable/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Iterable/index.scss
@@ -1,0 +1,59 @@
+@layer payload-default {
+  .iterable-diff {
+    &-label-container {
+      position: relative;
+      height: 20px;
+      display: flex;
+      flex-direction: row;
+      height: 100%;
+    }
+
+    &-label-prefix {
+      background-color: var(--theme-bg);
+      position: relative;
+      width: calc(var(--base) * 0.5);
+      height: 16px;
+      margin-left: calc((var(--base) * -0.5) - 5px);
+      margin-right: calc(var(--base) * 0.5);
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: 1px;
+        top: 8px;
+        transform: translateY(-50%);
+        width: 6px;
+        height: 6px;
+        background-color: var(--theme-elevation-200);
+        border-radius: 50%;
+        margin-right: 5px;
+      }
+    }
+    &__label {
+      font-weight: 400;
+      color: var(--theme-elevation-600);
+    }
+
+    &__locale-label {
+      background: var(--theme-elevation-100);
+      border-radius: var(--style-radius-s);
+      padding: calc(var(--base) * 0.2);
+      // border-radius: $style-radius-m;
+      [dir='ltr'] & {
+        margin-right: calc(var(--base) * 0.25);
+      }
+      [dir='rtl'] & {
+        margin-left: calc(var(--base) * 0.25);
+      }
+    }
+
+    // Space between each row
+    &__row:not(:first-of-type) {
+      margin-top: calc(var(--base) * 0.5);
+    }
+
+    &__no-rows {
+      color: var(--theme-elevation-400);
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Iterable/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Iterable/index.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import type { FieldDiffClientProps } from 'payload'
+
+import { getTranslation } from '@payloadcms/translations'
+import { useConfig, useTranslation } from '@payloadcms/ui'
+
+import './index.scss'
+
+import { fieldIsArrayType, fieldIsBlockType } from 'payload/shared'
+import React from 'react'
+
+import { useSelectedLocales } from '../../SelectedLocalesContext.js'
+import { DiffCollapser } from '../../DiffCollapser/index.js'
+import { RenderVersionFieldsToDiff } from '../../RenderVersionFieldsToDiff.js'
+import { getFieldsForRowComparison } from '../../utilities/getFieldsForRowComparison.js'
+
+const baseClass = 'iterable-diff'
+
+export const Iterable: React.FC<FieldDiffClientProps> = ({
+  baseVersionField,
+  comparisonValue: valueFrom,
+  field,
+  locale,
+  parentIsLocalized,
+  versionValue: valueTo,
+}) => {
+  const { i18n, t } = useTranslation()
+  const { selectedLocales } = useSelectedLocales()
+  const { config } = useConfig()
+
+  if (!fieldIsArrayType(field) && !fieldIsBlockType(field)) {
+    throw new Error(`Expected field to be an array or blocks type but got: ${field.type}`)
+  }
+
+  const valueToRowCount = Array.isArray(valueTo) ? valueTo.length : 0
+  const valueFromRowCount = Array.isArray(valueFrom) ? valueFrom.length : 0
+  const maxRows = Math.max(valueToRowCount, valueFromRowCount)
+
+  return (
+    <div className={baseClass}>
+      <DiffCollapser
+        field={field}
+        isIterable
+        Label={
+          'label' in field &&
+          field.label &&
+          typeof field.label !== 'function' && (
+            <span>
+              {locale && <span className={`${baseClass}__locale-label`}>{locale}</span>}
+              {getTranslation(field.label, i18n)}
+            </span>
+          )
+        }
+        locales={selectedLocales}
+        parentIsLocalized={parentIsLocalized}
+        valueFrom={valueFrom}
+        valueTo={valueTo}
+      >
+        {maxRows > 0 && (
+          <div className={`${baseClass}__rows`}>
+            {Array.from({ length: maxRows }, (_, i) => {
+              const valueToRow = valueTo?.[i] || {}
+              const valueFromRow = valueFrom?.[i] || {}
+
+              const { fields, versionFields } = getFieldsForRowComparison({
+                baseVersionField,
+                config,
+                field,
+                row: i,
+                valueFromRow,
+                valueToRow,
+              })
+
+              if (!versionFields?.length) {
+                // Rows without a diff create "holes" in the baseVersionField.rows (=versionFields) array - this is to maintain the correct row indexes.
+                // It does mean that this row has no diff and should not be rendered => skip it.
+                return null
+              }
+
+              const rowNumber = String(i + 1).padStart(2, '0')
+              const rowLabel = fieldIsArrayType(field)
+                ? `${t('general:item')} ${rowNumber}`
+                : `${t('fields:block')} ${rowNumber}`
+
+              return (
+                <div className={`${baseClass}__row`} key={i}>
+                  <DiffCollapser
+                    fields={fields}
+                    hideGutter={true}
+                    Label={
+                      <div className={`${baseClass}-label-container`}>
+                        <div className={`${baseClass}-label-prefix`}></div>
+                        <span className={`${baseClass}__label`}>{rowLabel}</span>
+                      </div>
+                    }
+                    locales={selectedLocales}
+                    parentIsLocalized={parentIsLocalized || field.localized}
+                    valueFrom={valueFromRow}
+                    valueTo={valueToRow}
+                  >
+                    <RenderVersionFieldsToDiff versionFields={versionFields} />
+                  </DiffCollapser>
+                </div>
+              )
+            })}
+          </div>
+        )}
+        {maxRows === 0 && (
+          <div className={`${baseClass}__no-rows`}>
+            {i18n.t('version:noRowsFound', {
+              label:
+                'labels' in field && field.labels?.plural
+                  ? getTranslation(field.labels.plural, i18n)
+                  : i18n.t('general:rows'),
+            })}
+          </div>
+        )}
+      </DiffCollapser>
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Relationship/generateLabelFromValue.ts
+++ b/packages/changes-button/src/vendor/diff/fields/Relationship/generateLabelFromValue.ts
@@ -1,0 +1,100 @@
+import type { PayloadRequest, RelationshipField, TypeWithID } from 'payload'
+
+import {
+  fieldAffectsData,
+  fieldIsPresentationalOnly,
+  fieldShouldBeLocalized,
+  flattenTopLevelFields,
+} from 'payload/shared'
+
+import type { RelationshipValue } from './index.js'
+
+export const generateLabelFromValue = async ({
+  field,
+  locale,
+  parentIsLocalized,
+  req,
+  value,
+}: {
+  field: RelationshipField
+  locale: string
+  parentIsLocalized: boolean
+  req: PayloadRequest
+  value: RelationshipValue
+}): Promise<string> => {
+  let relatedDoc: number | string | TypeWithID
+  let relationTo: string = field.relationTo as string
+  let valueToReturn: string = ''
+
+  if (typeof value === 'object' && 'relationTo' in value) {
+    relatedDoc = value.value
+    relationTo = value.relationTo
+  } else {
+    // Non-polymorphic relationship or deleted document
+    relatedDoc = value
+  }
+
+  const relatedCollection = req.payload.collections[relationTo].config
+
+  const useAsTitle = relatedCollection?.admin?.useAsTitle
+
+  const flattenedRelatedCollectionFields = flattenTopLevelFields(relatedCollection.fields, {
+    moveSubFieldsToTop: true,
+  })
+
+  const useAsTitleField = flattenedRelatedCollectionFields.find(
+    (f) => fieldAffectsData(f) && !fieldIsPresentationalOnly(f) && f.name === useAsTitle,
+  )
+  let titleFieldIsLocalized = false
+
+  if (useAsTitleField && fieldAffectsData(useAsTitleField)) {
+    titleFieldIsLocalized = fieldShouldBeLocalized({ field: useAsTitleField, parentIsLocalized })
+  }
+
+  if (typeof relatedDoc?.[useAsTitle] !== 'undefined') {
+    valueToReturn = relatedDoc[useAsTitle]
+  } else if (typeof relatedDoc === 'string' || typeof relatedDoc === 'number') {
+    // When relatedDoc is just an ID (due to maxDepth: 0), fetch the document to get the title
+    try {
+      const fetchedDoc = await req.payload.findByID({
+        id: relatedDoc,
+        collection: relationTo,
+        depth: 0,
+        locale: titleFieldIsLocalized ? locale : undefined,
+        req,
+        select: {
+          [useAsTitle]: true,
+        },
+      })
+
+      if (fetchedDoc?.[useAsTitle]) {
+        valueToReturn = fetchedDoc[useAsTitle]
+      } else {
+        valueToReturn = `${req.i18n.t('general:untitled')} - ID: ${relatedDoc}`
+      }
+    } catch (error) {
+      // Document might have been deleted or user doesn't have access
+      valueToReturn = `${req.i18n.t('general:untitled')} - ID: ${relatedDoc}`
+    }
+  } else {
+    valueToReturn = String(typeof relatedDoc === 'object' ? relatedDoc.id : relatedDoc)
+  }
+
+  if (
+    typeof valueToReturn === 'object' &&
+    valueToReturn &&
+    titleFieldIsLocalized &&
+    valueToReturn?.[locale]
+  ) {
+    valueToReturn = valueToReturn[locale]
+  }
+
+  if (
+    (valueToReturn && typeof valueToReturn === 'object' && valueToReturn !== null) ||
+    typeof valueToReturn !== 'string'
+  ) {
+    valueToReturn = JSON.stringify(valueToReturn)
+  }
+
+  return valueToReturn
+}

--- a/packages/changes-button/src/vendor/diff/fields/Relationship/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Relationship/index.scss
@@ -1,0 +1,90 @@
+@import '~@payloadcms/ui/scss';
+
+@layer payload-default {
+  .relationship-diff-container .field-diff-content {
+    padding: 0;
+    background: unset;
+  }
+
+  .relationship-diff-container--hasOne {
+    .relationship-diff {
+      min-width: 100%;
+      max-width: fit-content;
+    }
+  }
+
+  .relationship-diff-container--hasMany .field-diff-content {
+    background: var(--theme-elevation-50);
+    padding: 10px;
+
+    .html-diff {
+      display: flex;
+      min-width: 0;
+      max-width: max-content;
+      flex-wrap: wrap;
+      gap: calc(var(--base) * 0.5);
+    }
+
+    .relationship-diff {
+      padding: calc(var(--base) * 0.15) calc(var(--base) * 0.3);
+    }
+  }
+
+  .relationship-diff {
+    display: flex;
+    align-items: center;
+    border-radius: $style-radius-s;
+    border: 1px solid var(--theme-elevation-150);
+    position: relative;
+    font-family: var(--font-body);
+    max-height: calc(var(--base) * 3);
+    padding: calc(var(--base) * 0.35);
+
+    &[data-match-type='create'] {
+      border-color: var(--diff-create-pill-border);
+      color: var(--diff-create-parent-color);
+
+      * {
+        color: var(--diff-create-parent-color);
+      }
+    }
+
+    &[data-match-type='delete'] {
+      border-color: var(--diff-delete-pill-border);
+      color: var(--diff-delete-parent-color);
+      background-color: var(--diff-delete-pill-bg);
+      text-decoration-line: none !important;
+
+      * {
+        color: var(--diff-delete-parent-color);
+        text-decoration-line: none;
+      }
+
+      .relationship-diff__info {
+        text-decoration-line: line-through;
+      }
+    }
+
+    &__info {
+      font-weight: 500;
+    }
+
+    &__pill {
+      border-radius: $style-radius-s;
+      margin: 0 calc(var(--base) * 0.4) 0 calc(var(--base) * 0.2);
+      padding: 0 calc(var(--base) * 0.1);
+      background-color: var(--theme-elevation-150);
+      color: var(--theme-elevation-750);
+    }
+
+    &[data-match-type='create'] .relationship-diff__pill {
+      background-color: var(--diff-create-parent-bg);
+      color: var(--diff-create-pill-color);
+    }
+
+    &[data-match-type='delete'] .relationship-diff__pill {
+      background-color: var(--diff-delete-parent-bg);
+      color: var(--diff-delete-pill-color);
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Relationship/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Relationship/index.tsx
@@ -1,0 +1,338 @@
+import type {
+  PayloadRequest,
+  RelationshipField,
+  RelationshipFieldDiffServerComponent,
+  TypeWithID,
+} from 'payload'
+
+import { getTranslation, type I18nClient } from '@payloadcms/translations'
+import { FieldDiffContainer, getHTMLDiffComponents } from '@payloadcms/ui/rsc'
+
+import './index.scss'
+
+import React from 'react'
+
+import { generateLabelFromValue } from './generateLabelFromValue.js'
+
+const baseClass = 'relationship-diff'
+
+export type RelationshipValue =
+  | { relationTo: string; value: number | string | TypeWithID }
+  | (number | string | TypeWithID)
+
+export const Relationship: RelationshipFieldDiffServerComponent = ({
+  comparisonValue: valueFrom,
+  field,
+  i18n,
+  locale,
+  nestingLevel,
+  parentIsLocalized,
+  req,
+  versionValue: valueTo,
+}) => {
+  const hasMany =
+    ('hasMany' in field && field.hasMany) ||
+    // Check data structure (handles block swaps where schema may not match data)
+    Array.isArray(valueFrom) ||
+    Array.isArray(valueTo)
+  const polymorphic = Array.isArray(field.relationTo)
+
+  if (hasMany) {
+    return (
+      <ManyRelationshipDiff
+        field={field}
+        i18n={i18n}
+        locale={locale}
+        nestingLevel={nestingLevel}
+        parentIsLocalized={parentIsLocalized}
+        polymorphic={polymorphic}
+        req={req}
+        valueFrom={valueFrom as RelationshipValue[] | undefined}
+        valueTo={valueTo as RelationshipValue[] | undefined}
+      />
+    )
+  }
+
+  return (
+    <SingleRelationshipDiff
+      field={field}
+      i18n={i18n}
+      locale={locale}
+      nestingLevel={nestingLevel}
+      parentIsLocalized={parentIsLocalized}
+      polymorphic={polymorphic}
+      req={req}
+      valueFrom={valueFrom as RelationshipValue}
+      valueTo={valueTo as RelationshipValue}
+    />
+  )
+}
+
+export const SingleRelationshipDiff: React.FC<{
+  field: RelationshipField
+  i18n: I18nClient
+  locale: string
+  nestingLevel?: number
+  parentIsLocalized: boolean
+  polymorphic: boolean
+  req: PayloadRequest
+  valueFrom: RelationshipValue
+  valueTo: RelationshipValue
+}> = async (args) => {
+  const {
+    field,
+    i18n,
+    locale,
+    nestingLevel,
+    parentIsLocalized,
+    polymorphic,
+    req,
+    valueFrom,
+    valueTo,
+  } = args
+
+  const ReactDOMServer = (await import('react-dom/server')).default
+
+  const localeToUse =
+    locale ??
+    (req.payload.config?.localization && req.payload.config?.localization?.defaultLocale) ??
+    'en'
+
+  // Generate titles asynchronously before creating components
+  const [titleFrom, titleTo] = await Promise.all([
+    valueFrom
+      ? generateLabelFromValue({
+          field,
+          locale: localeToUse,
+          parentIsLocalized,
+          req,
+          value: valueFrom,
+        })
+      : Promise.resolve(null),
+    valueTo
+      ? generateLabelFromValue({
+          field,
+          locale: localeToUse,
+          parentIsLocalized,
+          req,
+          value: valueTo,
+        })
+      : Promise.resolve(null),
+  ])
+
+  const FromComponent = valueFrom ? (
+    <RelationshipDocumentDiff
+      field={field}
+      i18n={i18n}
+      locale={locale}
+      parentIsLocalized={parentIsLocalized}
+      polymorphic={polymorphic}
+      relationTo={
+        polymorphic
+          ? (valueFrom as { relationTo: string; value: TypeWithID }).relationTo
+          : (field.relationTo as string)
+      }
+      req={req}
+      showPill={true}
+      title={titleFrom}
+      value={valueFrom}
+    />
+  ) : null
+  const ToComponent = valueTo ? (
+    <RelationshipDocumentDiff
+      field={field}
+      i18n={i18n}
+      locale={locale}
+      parentIsLocalized={parentIsLocalized}
+      polymorphic={polymorphic}
+      relationTo={
+        polymorphic
+          ? (valueTo as { relationTo: string; value: TypeWithID }).relationTo
+          : (field.relationTo as string)
+      }
+      req={req}
+      showPill={true}
+      title={titleTo}
+      value={valueTo}
+    />
+  ) : null
+
+  const fromHTML = FromComponent ? ReactDOMServer.renderToStaticMarkup(FromComponent) : `<p></p>`
+  const toHTML = ToComponent ? ReactDOMServer.renderToStaticMarkup(ToComponent) : `<p></p>`
+
+  const diff = getHTMLDiffComponents({
+    fromHTML,
+    toHTML,
+    tokenizeByCharacter: false,
+  })
+
+  return (
+    <FieldDiffContainer
+      className={`${baseClass}-container ${baseClass}-container--hasOne`}
+      From={diff.From}
+      i18n={i18n}
+      label={{ label: field.label, locale }}
+      nestingLevel={nestingLevel}
+      To={diff.To}
+    />
+  )
+}
+
+const ManyRelationshipDiff: React.FC<{
+  field: RelationshipField
+  i18n: I18nClient
+  locale: string
+  nestingLevel?: number
+  parentIsLocalized: boolean
+  polymorphic: boolean
+  req: PayloadRequest
+  valueFrom: RelationshipValue[] | undefined
+  valueTo: RelationshipValue[] | undefined
+}> = async ({
+  field,
+  i18n,
+  locale,
+  nestingLevel,
+  parentIsLocalized,
+  polymorphic,
+  req,
+  valueFrom,
+  valueTo,
+}) => {
+  const ReactDOMServer = (await import('react-dom/server')).default
+
+  const fromArr = Array.isArray(valueFrom) ? valueFrom : []
+  const toArr = Array.isArray(valueTo) ? valueTo : []
+
+  const localeToUse =
+    locale ??
+    (req.payload.config?.localization && req.payload.config?.localization?.defaultLocale) ??
+    'en'
+
+  // Generate all titles asynchronously before creating components
+  const [titlesFrom, titlesTo] = await Promise.all([
+    Promise.all(
+      fromArr.map((val) =>
+        generateLabelFromValue({
+          field,
+          locale: localeToUse,
+          parentIsLocalized,
+          req,
+          value: val,
+        }),
+      ),
+    ),
+    Promise.all(
+      toArr.map((val) =>
+        generateLabelFromValue({
+          field,
+          locale: localeToUse,
+          parentIsLocalized,
+          req,
+          value: val,
+        }),
+      ),
+    ),
+  ])
+
+  const makeNodes = (list: RelationshipValue[], titles: string[]) =>
+    list.map((val, idx) => (
+      <RelationshipDocumentDiff
+        field={field}
+        i18n={i18n}
+        key={idx}
+        locale={locale}
+        parentIsLocalized={parentIsLocalized}
+        polymorphic={polymorphic}
+        relationTo={
+          polymorphic
+            ? (val as { relationTo: string; value: TypeWithID }).relationTo
+            : (field.relationTo as string)
+        }
+        req={req}
+        showPill={polymorphic}
+        title={titles[idx]}
+        value={val}
+      />
+    ))
+
+  const fromNodes =
+    fromArr.length > 0 ? makeNodes(fromArr, titlesFrom) : <p className={`${baseClass}__empty`}></p>
+
+  const toNodes =
+    toArr.length > 0 ? makeNodes(toArr, titlesTo) : <p className={`${baseClass}__empty`}></p>
+
+  const fromHTML = ReactDOMServer.renderToStaticMarkup(fromNodes)
+  const toHTML = ReactDOMServer.renderToStaticMarkup(toNodes)
+
+  const diff = getHTMLDiffComponents({
+    fromHTML,
+    toHTML,
+    tokenizeByCharacter: false,
+  })
+
+  return (
+    <FieldDiffContainer
+      className={`${baseClass}-container ${baseClass}-container--hasMany`}
+      From={diff.From}
+      i18n={i18n}
+      label={{ label: field.label, locale }}
+      nestingLevel={nestingLevel}
+      To={diff.To}
+    />
+  )
+}
+
+const RelationshipDocumentDiff = ({
+  field,
+  i18n,
+  locale,
+  parentIsLocalized,
+  polymorphic,
+  relationTo,
+  req,
+  showPill = false,
+  title,
+  value,
+}: {
+  field: RelationshipField
+  i18n: I18nClient
+  locale: string
+  parentIsLocalized: boolean
+  polymorphic: boolean
+  relationTo: string
+  req: PayloadRequest
+  showPill?: boolean
+  title: null | string
+  value: RelationshipValue
+}) => {
+  let pillLabel: null | string = null
+  if (showPill) {
+    const collectionConfig = req.payload.collections[relationTo].config
+    pillLabel = collectionConfig.labels?.singular
+      ? getTranslation(collectionConfig.labels.singular, i18n)
+      : collectionConfig.slug
+  }
+
+  return (
+    <div
+      className={`${baseClass}`}
+      data-enable-match="true"
+      data-id={
+        polymorphic
+          ? (value as { relationTo: string; value: TypeWithID }).value.id
+          : (value as TypeWithID).id
+      }
+      data-relation-to={relationTo}
+    >
+      {pillLabel && (
+        <span className={`${baseClass}__pill`} data-enable-match="false">
+          {pillLabel}
+        </span>
+      )}
+      <strong className={`${baseClass}__info`} data-enable-match="false">
+        {title}
+      </strong>
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Row/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Row/index.tsx
@@ -1,0 +1,16 @@
+'use client'
+import type { RowFieldDiffClientComponent } from 'payload'
+
+import React from 'react'
+
+import { RenderVersionFieldsToDiff } from '../../RenderVersionFieldsToDiff.js'
+
+const baseClass = 'row-diff'
+
+export const Row: RowFieldDiffClientComponent = ({ baseVersionField }) => {
+  return (
+    <div className={baseClass}>
+      <RenderVersionFieldsToDiff versionFields={baseVersionField.fields} />
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Select/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Select/index.scss
@@ -1,0 +1,4 @@
+@layer payload-default {
+  .select-diff {
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Select/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Select/index.tsx
@@ -1,0 +1,122 @@
+'use client'
+import type { I18nClient } from '@payloadcms/translations'
+import type { Option, SelectField, SelectFieldDiffClientComponent } from 'payload'
+
+import { getTranslation } from '@payloadcms/translations'
+import {
+  escapeDiffHTML,
+  FieldDiffContainer,
+  getHTMLDiffComponents,
+  unescapeDiffHTML,
+  useTranslation,
+} from '@payloadcms/ui'
+import React from 'react'
+
+import './index.scss'
+
+const baseClass = 'select-diff'
+
+const getOptionsToRender = (
+  value: string,
+  options: SelectField['options'],
+  hasMany: boolean,
+): Option | Option[] => {
+  if (hasMany && Array.isArray(value)) {
+    return value.map(
+      (val) =>
+        options.find((option) => (typeof option === 'string' ? option : option.value) === val) ||
+        String(val),
+    )
+  }
+  return (
+    options.find((option) => (typeof option === 'string' ? option : option.value) === value) ||
+    String(value)
+  )
+}
+
+/**
+ * Translates option labels while ensuring they are strings.
+ * If `options.label` is a JSX element, it falls back to `options.value` because `DiffViewer`
+ * expects all values to be strings.
+ */
+const getTranslatedOptions = (options: Option | Option[], i18n: I18nClient): string => {
+  if (Array.isArray(options)) {
+    return options
+      .map((option) => {
+        if (typeof option === 'string') {
+          return option
+        }
+        const translatedLabel = getTranslation(option.label, i18n)
+
+        // Ensure the result is a string, otherwise use option.value
+        return typeof translatedLabel === 'string' ? translatedLabel : option.value
+      })
+      .join(', ')
+  }
+
+  if (typeof options === 'string') {
+    return options
+  }
+
+  const translatedLabel = getTranslation(options.label, i18n)
+
+  return typeof translatedLabel === 'string' ? translatedLabel : options.value
+}
+
+export const Select: SelectFieldDiffClientComponent = ({
+  comparisonValue: valueFrom,
+  diffMethod,
+  field,
+  locale,
+  nestingLevel,
+  versionValue: valueTo,
+}) => {
+  const { i18n } = useTranslation()
+
+  const options = 'options' in field && field.options
+
+  const renderedValueFrom =
+    typeof valueFrom !== 'undefined'
+      ? getTranslatedOptions(
+          getOptionsToRender(
+            typeof valueFrom === 'string' ? valueFrom : JSON.stringify(valueFrom),
+            options,
+            field.hasMany,
+          ),
+          i18n,
+        )
+      : ''
+
+  const renderedValueTo =
+    typeof valueTo !== 'undefined'
+      ? getTranslatedOptions(
+          getOptionsToRender(
+            typeof valueTo === 'string' ? valueTo : JSON.stringify(valueTo),
+            options,
+            field.hasMany,
+          ),
+          i18n,
+        )
+      : ''
+
+  const { From, To } = getHTMLDiffComponents({
+    fromHTML: '<p>' + escapeDiffHTML(renderedValueFrom) + '</p>',
+    postProcess: unescapeDiffHTML,
+    toHTML: '<p>' + escapeDiffHTML(renderedValueTo) + '</p>',
+    tokenizeByCharacter: true,
+  })
+
+  return (
+    <FieldDiffContainer
+      className={baseClass}
+      From={From}
+      i18n={i18n}
+      label={{
+        label: field.label,
+        locale,
+      }}
+      nestingLevel={nestingLevel}
+      To={To}
+    />
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Tabs/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Tabs/index.scss
@@ -1,0 +1,9 @@
+@layer payload-default {
+  .tabs-diff {
+    // Space between each tab or tab locale
+    &__tab:not(:first-of-type),
+    &__tab-locale:not(:first-of-type) {
+      margin-top: var(--base);
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Tabs/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Tabs/index.tsx
@@ -1,0 +1,120 @@
+'use client'
+import type {
+  ClientTab,
+  FieldDiffClientProps,
+  TabsFieldClient,
+  TabsFieldDiffClientComponent,
+  VersionTab,
+} from 'payload'
+
+import { getTranslation } from '@payloadcms/translations'
+import { useTranslation } from '@payloadcms/ui'
+import React from 'react'
+
+import './index.scss'
+import { useSelectedLocales } from '../../SelectedLocalesContext.js'
+import { DiffCollapser } from '../../DiffCollapser/index.js'
+import { RenderVersionFieldsToDiff } from '../../RenderVersionFieldsToDiff.js'
+
+const baseClass = 'tabs-diff'
+
+export const Tabs: TabsFieldDiffClientComponent = (props) => {
+  const { baseVersionField, comparisonValue: valueFrom, field, versionValue: valueTo } = props
+  const { selectedLocales } = useSelectedLocales()
+
+  return (
+    <div className={baseClass}>
+      {baseVersionField.tabs.map((tab, i) => {
+        if (!tab?.fields?.length) {
+          return null
+        }
+        const fieldTab = field.tabs?.[i]
+        if (!fieldTab) {
+          return null
+        }
+        return (
+          <div className={`${baseClass}__tab`} key={i}>
+            {(() => {
+              if ('name' in fieldTab && selectedLocales && fieldTab.localized) {
+                // Named localized tab
+                return selectedLocales.map((locale, index) => {
+                  const localizedTabProps: TabProps = {
+                    ...props,
+                    comparisonValue: valueFrom?.[tab.name]?.[locale],
+                    fieldTab,
+                    locale,
+                    tab,
+                    versionValue: valueTo?.[tab.name]?.[locale],
+                  }
+                  return (
+                    <div className={`${baseClass}__tab-locale`} key={[locale, index].join('-')}>
+                      <div className={`${baseClass}__tab-locale-value`}>
+                        <Tab key={locale} {...localizedTabProps} />
+                      </div>
+                    </div>
+                  )
+                })
+              } else if ('name' in tab && tab.name) {
+                // Named tab
+                const namedTabProps: TabProps = {
+                  ...props,
+                  comparisonValue: valueFrom?.[tab.name],
+                  fieldTab,
+                  tab,
+                  versionValue: valueTo?.[tab.name],
+                }
+                return <Tab key={i} {...namedTabProps} />
+              } else {
+                // Unnamed tab
+                return <Tab fieldTab={fieldTab} key={i} {...props} tab={tab} />
+              }
+            })()}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+type TabProps = {
+  fieldTab: ClientTab
+  tab: VersionTab
+} & FieldDiffClientProps<TabsFieldClient>
+
+const Tab: React.FC<TabProps> = ({
+  comparisonValue: valueFrom,
+  fieldTab,
+  locale,
+  parentIsLocalized,
+  tab,
+  versionValue: valueTo,
+}) => {
+  const { i18n } = useTranslation()
+  const { selectedLocales } = useSelectedLocales()
+
+  if (!tab.fields?.length) {
+    return null
+  }
+
+  return (
+    <DiffCollapser
+      fields={fieldTab.fields}
+      Label={
+        'label' in tab &&
+        tab.label &&
+        typeof tab.label !== 'function' && (
+          <span>
+            {locale && <span className={`${baseClass}__locale-label`}>{locale}</span>}
+            {getTranslation(tab.label, i18n)}
+          </span>
+        )
+      }
+      locales={selectedLocales}
+      parentIsLocalized={parentIsLocalized || fieldTab.localized}
+      valueFrom={valueFrom}
+      valueTo={valueTo}
+    >
+      <RenderVersionFieldsToDiff versionFields={tab.fields} />
+    </DiffCollapser>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Text/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Text/index.scss
@@ -1,0 +1,4 @@
+@layer payload-default {
+  .text-diff {
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Text/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Text/index.tsx
@@ -1,0 +1,98 @@
+'use client'
+import type { TextFieldDiffClientComponent } from 'payload'
+
+import {
+  escapeDiffHTML,
+  FieldDiffContainer,
+  getHTMLDiffComponents,
+  unescapeDiffHTML,
+  useTranslation,
+} from '@payloadcms/ui'
+import React from 'react'
+
+import './index.scss'
+
+const baseClass = 'text-diff'
+
+function formatValue(value: unknown): {
+  tokenizeByCharacter: boolean
+  value: string
+} {
+  if (typeof value === 'string') {
+    return { tokenizeByCharacter: true, value: escapeDiffHTML(value) }
+  }
+  if (typeof value === 'number') {
+    return {
+      tokenizeByCharacter: true,
+      value: String(value),
+    }
+  }
+  if (typeof value === 'boolean') {
+    return {
+      tokenizeByCharacter: false,
+      value: String(value),
+    }
+  }
+
+  if (value && typeof value === 'object') {
+    return {
+      tokenizeByCharacter: false,
+      value: `<pre>${escapeDiffHTML(JSON.stringify(value, null, 2))}</pre>`,
+    }
+  }
+
+  return {
+    tokenizeByCharacter: true,
+    value: undefined,
+  }
+}
+
+export const Text: TextFieldDiffClientComponent = ({
+  comparisonValue: valueFrom,
+  field,
+  locale,
+  nestingLevel,
+  versionValue: valueTo,
+}) => {
+  const { i18n } = useTranslation()
+
+  let placeholder = ''
+
+  if (valueTo == valueFrom) {
+    placeholder = `<span class="html-diff-no-value"><span>`
+  }
+
+  const formattedValueFrom = formatValue(valueFrom)
+  const formattedValueTo = formatValue(valueTo)
+
+  let tokenizeByCharacter = true
+  if (formattedValueFrom.value?.length) {
+    tokenizeByCharacter = formattedValueFrom.tokenizeByCharacter
+  } else if (formattedValueTo.value?.length) {
+    tokenizeByCharacter = formattedValueTo.tokenizeByCharacter
+  }
+
+  const renderedValueFrom = formattedValueFrom.value ?? placeholder
+  const renderedValueTo: string = formattedValueTo.value ?? placeholder
+
+  const { From, To } = getHTMLDiffComponents({
+    fromHTML: '<p>' + renderedValueFrom + '</p>',
+    postProcess: unescapeDiffHTML,
+    toHTML: '<p>' + renderedValueTo + '</p>',
+    tokenizeByCharacter,
+  })
+
+  return (
+    <FieldDiffContainer
+      className={baseClass}
+      From={From}
+      i18n={i18n}
+      label={{
+        label: field.label,
+        locale,
+      }}
+      nestingLevel={nestingLevel}
+      To={To}
+    />
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/Upload/index.scss
+++ b/packages/changes-button/src/vendor/diff/fields/Upload/index.scss
@@ -1,0 +1,120 @@
+@import '~@payloadcms/ui/scss';
+
+@layer payload-default {
+  .upload-diff-container .field-diff-content {
+    padding: 0;
+    background: unset;
+  }
+
+  .upload-diff-hasMany {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--base) * 0.4);
+  }
+
+  .upload-diff {
+    min-width: 100%;
+    max-width: fit-content;
+    display: flex;
+    align-items: center;
+    background-color: var(--theme-elevation-50);
+    border-radius: $style-radius-s;
+    border: 1px solid var(--theme-elevation-150);
+    position: relative;
+    font-family: var(--font-body);
+    max-height: calc(var(--base) * 3);
+    padding: calc(var(--base) * 0.1);
+
+    &[data-match-type='create'] {
+      border-color: var(--diff-create-pill-border);
+      color: var(--diff-create-parent-color);
+
+      * {
+        color: var(--diff-create-parent-color);
+      }
+
+      .upload-diff__thumbnail {
+        border-radius: 0px;
+        border-color: var(--diff-create-pill-border);
+        background-color: none;
+      }
+    }
+
+    &[data-match-type='delete'] {
+      border-color: var(--diff-delete-pill-border);
+      text-decoration-line: none;
+      color: var(--diff-delete-parent-color);
+      background-color: var(--diff-delete-pill-bg);
+
+      * {
+        text-decoration-line: none;
+        color: var(--diff-delete-parent-color);
+      }
+
+      .upload-diff__thumbnail {
+        border-radius: 0px;
+        border-color: var(--diff-delete-pill-border);
+        background-color: none;
+      }
+    }
+
+    &__card {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      width: 100%;
+    }
+
+    &__thumbnail {
+      width: calc(var(--base) * 3 - base(0.8) * 2);
+      height: calc(var(--base) * 3 - base(0.8) * 2);
+      position: relative;
+      overflow: hidden;
+      flex-shrink: 0;
+      border-radius: 0px;
+      border: 1px solid var(--theme-elevation-100);
+
+      img,
+      svg {
+        position: absolute;
+        object-fit: cover;
+        width: 100%;
+        height: 100%;
+        border-radius: 0px;
+      }
+    }
+
+    &__info {
+      flex-grow: 1;
+      display: flex;
+      align-items: flex-start;
+      flex-direction: column;
+      padding: calc(var(--base) * 0.25) calc(var(--base) * 0.6);
+      justify-content: space-between;
+      font-weight: 400;
+
+      strong {
+        font-weight: 500;
+      }
+    }
+
+    &__pill {
+      border-radius: $style-radius-s;
+      margin-left: calc(var(--base) * 0.6);
+      padding: 0 calc(var(--base) * 0.1);
+
+      background-color: var(--theme-elevation-150);
+      color: var(--theme-elevation-750);
+    }
+
+    &[data-match-type='create'] .upload-diff__pill {
+      background-color: var(--diff-create-parent-bg);
+      color: var(--diff-create-pill-color);
+    }
+
+    &[data-match-type='delete'] .upload-diff__pill {
+      background-color: var(--diff-delete-parent-bg);
+      color: var(--diff-delete-pill-color);
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/fields/Upload/index.tsx
+++ b/packages/changes-button/src/vendor/diff/fields/Upload/index.tsx
@@ -1,0 +1,307 @@
+import type {
+  FileData,
+  PayloadRequest,
+  TypeWithID,
+  UploadField,
+  UploadFieldDiffServerComponent,
+} from 'payload'
+
+import { getTranslation, type I18nClient } from '@payloadcms/translations'
+import { FieldDiffContainer, File, getHTMLDiffComponents } from '@payloadcms/ui/rsc'
+
+import './index.scss'
+
+import React from 'react'
+
+const baseClass = 'upload-diff'
+
+type NonPolyUploadDoc = (FileData & TypeWithID) | number | string
+type PolyUploadDoc = { relationTo: string; value: (FileData & TypeWithID) | number | string }
+
+type UploadDoc = NonPolyUploadDoc | PolyUploadDoc
+
+export const Upload: UploadFieldDiffServerComponent = (args) => {
+  const {
+    comparisonValue: valueFrom,
+    field,
+    i18n,
+    locale,
+    nestingLevel,
+    req,
+    versionValue: valueTo,
+  } = args
+  const hasMany = 'hasMany' in field && field.hasMany && Array.isArray(valueTo)
+  const polymorphic = Array.isArray(field.relationTo)
+
+  if (hasMany) {
+    return (
+      <HasManyUploadDiff
+        field={field}
+        i18n={i18n}
+        locale={locale}
+        nestingLevel={nestingLevel}
+        polymorphic={polymorphic}
+        req={req}
+        valueFrom={valueFrom as UploadDoc[]}
+        valueTo={valueTo as UploadDoc[]}
+      />
+    )
+  }
+
+  return (
+    <SingleUploadDiff
+      field={field}
+      i18n={i18n}
+      locale={locale}
+      nestingLevel={nestingLevel}
+      polymorphic={polymorphic}
+      req={req}
+      valueFrom={valueFrom as UploadDoc}
+      valueTo={valueTo as UploadDoc}
+    />
+  )
+}
+
+export const HasManyUploadDiff: React.FC<{
+  field: UploadField
+  i18n: I18nClient
+  locale: string
+  nestingLevel?: number
+  polymorphic: boolean
+  req: PayloadRequest
+  valueFrom: Array<UploadDoc>
+  valueTo: Array<UploadDoc>
+}> = async (args) => {
+  const { field, i18n, locale, nestingLevel, polymorphic, req, valueFrom, valueTo } = args
+  const ReactDOMServer = (await import('react-dom/server')).default
+
+  let From: React.ReactNode = ''
+  let To: React.ReactNode = ''
+
+  const showCollectionSlug = Array.isArray(field.relationTo)
+
+  const getUploadDocKey = (uploadDoc: UploadDoc): number | string => {
+    if (typeof uploadDoc === 'object' && 'relationTo' in uploadDoc) {
+      // Polymorphic case
+      const value = uploadDoc.value
+      return typeof value === 'object' ? value.id : value
+    }
+    // Non-polymorphic case
+    return typeof uploadDoc === 'object' ? uploadDoc.id : uploadDoc
+  }
+
+  const FromComponents = valueFrom
+    ? valueFrom.map((uploadDoc) => (
+        <UploadDocumentDiff
+          i18n={i18n}
+          key={getUploadDocKey(uploadDoc)}
+          polymorphic={polymorphic}
+          relationTo={field.relationTo}
+          req={req}
+          showCollectionSlug={showCollectionSlug}
+          uploadDoc={uploadDoc}
+        />
+      ))
+    : null
+  const ToComponents = valueTo
+    ? valueTo.map((uploadDoc) => (
+        <UploadDocumentDiff
+          i18n={i18n}
+          key={getUploadDocKey(uploadDoc)}
+          polymorphic={polymorphic}
+          relationTo={field.relationTo}
+          req={req}
+          showCollectionSlug={showCollectionSlug}
+          uploadDoc={uploadDoc}
+        />
+      ))
+    : null
+
+  const diffResult = getHTMLDiffComponents({
+    fromHTML:
+      `<div class="${baseClass}-hasMany">` +
+      (FromComponents
+        ? FromComponents.map(
+            (component) => `<div>${ReactDOMServer.renderToStaticMarkup(component)}</div>`,
+          ).join('')
+        : '') +
+      '</div>',
+    toHTML:
+      `<div class="${baseClass}-hasMany">` +
+      (ToComponents
+        ? ToComponents.map(
+            (component) => `<div>${ReactDOMServer.renderToStaticMarkup(component)}</div>`,
+          ).join('')
+        : '') +
+      '</div>',
+    tokenizeByCharacter: false,
+  })
+  From = diffResult.From
+  To = diffResult.To
+
+  return (
+    <FieldDiffContainer
+      className={`${baseClass}-container ${baseClass}-container--hasMany`}
+      From={From}
+      i18n={i18n}
+      label={{
+        label: field.label,
+        locale,
+      }}
+      nestingLevel={nestingLevel}
+      To={To}
+    />
+  )
+}
+
+export const SingleUploadDiff: React.FC<{
+  field: UploadField
+  i18n: I18nClient
+  locale: string
+  nestingLevel?: number
+  polymorphic: boolean
+  req: PayloadRequest
+  valueFrom: UploadDoc
+  valueTo: UploadDoc
+}> = async (args) => {
+  const { field, i18n, locale, nestingLevel, polymorphic, req, valueFrom, valueTo } = args
+
+  const ReactDOMServer = (await import('react-dom/server')).default
+
+  let From: React.ReactNode = ''
+  let To: React.ReactNode = ''
+
+  const showCollectionSlug = Array.isArray(field.relationTo)
+
+  const FromComponent = valueFrom ? (
+    <UploadDocumentDiff
+      i18n={i18n}
+      polymorphic={polymorphic}
+      relationTo={field.relationTo}
+      req={req}
+      showCollectionSlug={showCollectionSlug}
+      uploadDoc={valueFrom}
+    />
+  ) : null
+  const ToComponent = valueTo ? (
+    <UploadDocumentDiff
+      i18n={i18n}
+      polymorphic={polymorphic}
+      relationTo={field.relationTo}
+      req={req}
+      showCollectionSlug={showCollectionSlug}
+      uploadDoc={valueTo}
+    />
+  ) : null
+
+  const fromHtml = FromComponent
+    ? ReactDOMServer.renderToStaticMarkup(FromComponent)
+    : '<p>' + '' + '</p>'
+  const toHtml = ToComponent
+    ? ReactDOMServer.renderToStaticMarkup(ToComponent)
+    : '<p>' + '' + '</p>'
+
+  const diffResult = getHTMLDiffComponents({
+    fromHTML: fromHtml,
+    toHTML: toHtml,
+    tokenizeByCharacter: false,
+  })
+  From = diffResult.From
+  To = diffResult.To
+
+  return (
+    <FieldDiffContainer
+      className={`${baseClass}-container ${baseClass}-container--hasOne`}
+      From={From}
+      i18n={i18n}
+      label={{
+        label: field.label,
+        locale,
+      }}
+      nestingLevel={nestingLevel}
+      To={To}
+    />
+  )
+}
+
+const UploadDocumentDiff = (args: {
+  i18n: I18nClient
+  polymorphic: boolean
+  relationTo: string | string[]
+  req: PayloadRequest
+  showCollectionSlug?: boolean
+  uploadDoc: UploadDoc
+}) => {
+  const { i18n, polymorphic, relationTo, req, showCollectionSlug, uploadDoc } = args
+
+  let thumbnailSRC: string = ''
+
+  const value = polymorphic
+    ? (uploadDoc as { relationTo: string; value: FileData & TypeWithID }).value
+    : (uploadDoc as FileData & TypeWithID)
+
+  if (value && typeof value === 'object' && 'thumbnailURL' in value) {
+    thumbnailSRC =
+      (typeof value.thumbnailURL === 'string' && value.thumbnailURL) ||
+      (typeof value.url === 'string' && value.url) ||
+      ''
+  }
+
+  let filename: string
+  if (value && typeof value === 'object') {
+    filename = value.filename
+  } else {
+    filename = `${i18n.t('general:untitled')} - ID: ${uploadDoc as number | string}`
+  }
+
+  let pillLabel: null | string = null
+
+  if (showCollectionSlug) {
+    let collectionSlug: string
+    if (polymorphic && typeof uploadDoc === 'object' && 'relationTo' in uploadDoc) {
+      collectionSlug = uploadDoc.relationTo
+    } else {
+      collectionSlug = typeof relationTo === 'string' ? relationTo : relationTo[0]
+    }
+    const uploadConfig = req.payload.collections[collectionSlug].config
+    pillLabel = uploadConfig.labels?.singular
+      ? getTranslation(uploadConfig.labels.singular, i18n)
+      : uploadConfig.slug
+  }
+
+  let id: number | string | undefined
+  if (polymorphic && typeof uploadDoc === 'object' && 'relationTo' in uploadDoc) {
+    const polyValue = uploadDoc.value
+    id = typeof polyValue === 'object' ? polyValue.id : polyValue
+  } else if (typeof uploadDoc === 'object' && 'id' in uploadDoc) {
+    id = uploadDoc.id
+  } else if (typeof uploadDoc === 'string' || typeof uploadDoc === 'number') {
+    id = uploadDoc
+  }
+
+  const alt =
+    (value && typeof value === 'object' && (value as { alt?: string }).alt) || filename || ''
+
+  return (
+    <div
+      className={`${baseClass}`}
+      data-enable-match="true"
+      data-id={id}
+      data-relation-to={relationTo}
+    >
+      <div className={`${baseClass}__card`}>
+        <div className={`${baseClass}__thumbnail`}>
+          {thumbnailSRC?.length ? <img alt={alt} src={thumbnailSRC} /> : <File />}
+        </div>
+        {pillLabel && (
+          <div className={`${baseClass}__pill`} data-enable-match="false">
+            <span>{pillLabel}</span>
+          </div>
+        )}
+        <div className={`${baseClass}__info`} data-enable-match="false">
+          <strong>{filename}</strong>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/changes-button/src/vendor/diff/fields/index.ts
+++ b/packages/changes-button/src/vendor/diff/fields/index.ts
@@ -1,0 +1,40 @@
+import type { FieldDiffClientProps, FieldDiffServerProps, FieldTypes } from 'payload'
+
+import { Collapsible } from './Collapsible/index.js'
+import { DateDiffComponent } from './Date/index.js'
+import { Group } from './Group/index.js'
+import { Iterable } from './Iterable/index.js'
+import { Relationship } from './Relationship/index.js'
+import { Row } from './Row/index.js'
+import { Select } from './Select/index.js'
+import { Tabs } from './Tabs/index.js'
+import { Text } from './Text/index.js'
+import { Upload } from './Upload/index.js'
+
+export const diffComponents: Record<
+  FieldTypes,
+  React.ComponentType<FieldDiffClientProps | FieldDiffServerProps>
+> = {
+  array: Iterable,
+  blocks: Iterable,
+  checkbox: Text,
+  code: Text,
+  collapsible: Collapsible,
+  date: DateDiffComponent,
+  email: Text,
+  group: Group,
+  join: null,
+  json: Text,
+  number: Text,
+  point: Text,
+  radio: Select,
+  relationship: Relationship,
+  richText: Text,
+  row: Row,
+  select: Select,
+  tabs: Tabs,
+  text: Text,
+  textarea: Text,
+  ui: null,
+  upload: Upload,
+}

--- a/packages/changes-button/src/vendor/diff/index.scss
+++ b/packages/changes-button/src/vendor/diff/index.scss
@@ -1,0 +1,24 @@
+@import '~@payloadcms/ui/scss';
+
+@layer payload-default {
+  .render-field-diffs {
+    display: flex;
+    flex-direction: column;
+    gap: var(--base);
+
+    [role='banner'] {
+      display: none !important;
+    }
+
+    &__field {
+      overflow-wrap: anywhere;
+      display: flex;
+      flex-direction: column;
+      gap: var(--base);
+    }
+
+    @include small-break {
+      gap: calc(var(--base) / 2);
+    }
+  }
+}

--- a/packages/changes-button/src/vendor/diff/index.tsx
+++ b/packages/changes-button/src/vendor/diff/index.tsx
@@ -1,0 +1,8 @@
+import { buildVersionFields, type BuildVersionFieldsArgs } from './buildVersionFields.js'
+import { RenderVersionFieldsToDiff } from './RenderVersionFieldsToDiff.js'
+
+export const RenderDiff = (args: BuildVersionFieldsArgs): React.ReactNode => {
+  const { versionFields } = buildVersionFields(args)
+
+  return <RenderVersionFieldsToDiff parent={true} versionFields={versionFields} />
+}

--- a/packages/changes-button/src/vendor/diff/utilities/countChangedFields.ts
+++ b/packages/changes-button/src/vendor/diff/utilities/countChangedFields.ts
@@ -1,0 +1,255 @@
+import type { ArrayFieldClient, BlocksFieldClient, ClientConfig, ClientField } from 'payload'
+
+import { fieldShouldBeLocalized, groupHasName } from 'payload/shared'
+
+import { fieldHasChanges } from './fieldHasChanges.js'
+import { getFieldsForRowComparison } from './getFieldsForRowComparison.js'
+
+type Args = {
+  config: ClientConfig
+  fields: ClientField[]
+  locales: string[] | undefined
+  parentIsLocalized: boolean
+  valueFrom: unknown
+  valueTo: unknown
+}
+
+/**
+ * Recursively counts the number of changed fields between comparison and
+ * version data for a given set of fields.
+ */
+export function countChangedFields({
+  config,
+  fields,
+  locales,
+  parentIsLocalized,
+  valueFrom,
+  valueTo,
+}: Args) {
+  let count = 0
+
+  fields.forEach((field) => {
+    // Don't count the id field since it is not displayed in the UI
+    if ('name' in field && field.name === 'id') {
+      return
+    }
+    const fieldType = field.type
+    switch (fieldType) {
+      // Iterable fields are arrays and blocks fields. We iterate over each row and
+      // count the number of changed fields in each.
+      case 'array':
+      case 'blocks': {
+        if (locales && fieldShouldBeLocalized({ field, parentIsLocalized })) {
+          locales.forEach((locale) => {
+            const valueFromRows = valueFrom?.[field.name]?.[locale] ?? []
+            const valueToRows = valueTo?.[field.name]?.[locale] ?? []
+            count += countChangedFieldsInRows({
+              config,
+              field,
+              locales,
+              parentIsLocalized: parentIsLocalized || field.localized,
+              valueFromRows,
+              valueToRows,
+            })
+          })
+        } else {
+          const valueFromRows = valueFrom?.[field.name] ?? []
+          const valueToRows = valueTo?.[field.name] ?? []
+          count += countChangedFieldsInRows({
+            config,
+            field,
+            locales,
+            parentIsLocalized: parentIsLocalized || field.localized,
+            valueFromRows,
+            valueToRows,
+          })
+        }
+        break
+      }
+
+      // Regular fields without nested fields.
+      case 'checkbox':
+      case 'code':
+      case 'date':
+      case 'email':
+      case 'join':
+      case 'json':
+      case 'number':
+      case 'point':
+      case 'radio':
+      case 'relationship':
+      case 'richText':
+      case 'select':
+      case 'text':
+      case 'textarea':
+      case 'upload': {
+        // Fields that have a name and contain data. We can just check if the data has changed.
+        if (locales && fieldShouldBeLocalized({ field, parentIsLocalized })) {
+          locales.forEach((locale) => {
+            if (
+              fieldHasChanges(valueTo?.[field.name]?.[locale], valueFrom?.[field.name]?.[locale])
+            ) {
+              count++
+            }
+          })
+        } else if (fieldHasChanges(valueTo?.[field.name], valueFrom?.[field.name])) {
+          count++
+        }
+        break
+      }
+      // Fields that have nested fields, but don't nest their fields' data.
+      case 'collapsible':
+      case 'row': {
+        count += countChangedFields({
+          config,
+          fields: field.fields,
+          locales,
+          parentIsLocalized: parentIsLocalized || field.localized,
+          valueFrom,
+          valueTo,
+        })
+
+        break
+      }
+
+      // Fields that have nested fields and nest their fields' data.
+      case 'group': {
+        if (groupHasName(field)) {
+          if (locales && fieldShouldBeLocalized({ field, parentIsLocalized })) {
+            locales.forEach((locale) => {
+              count += countChangedFields({
+                config,
+                fields: field.fields,
+                locales,
+                parentIsLocalized: parentIsLocalized || field.localized,
+                valueFrom: valueFrom?.[field.name]?.[locale],
+                valueTo: valueTo?.[field.name]?.[locale],
+              })
+            })
+          } else {
+            count += countChangedFields({
+              config,
+              fields: field.fields,
+              locales,
+              parentIsLocalized: parentIsLocalized || field.localized,
+              valueFrom: valueFrom?.[field.name],
+              valueTo: valueTo?.[field.name],
+            })
+          }
+        } else {
+          // Unnamed group field: data is NOT nested under `field.name`
+          count += countChangedFields({
+            config,
+            fields: field.fields,
+            locales,
+            parentIsLocalized: parentIsLocalized || field.localized,
+            valueFrom,
+            valueTo,
+          })
+        }
+        break
+      }
+
+      // Each tab in a tabs field has nested fields. The fields data may be
+      // nested or not depending on the existence of a name property.
+      case 'tabs': {
+        field.tabs.forEach((tab) => {
+          if ('name' in tab && locales && tab.localized) {
+            // Named localized tab
+            locales.forEach((locale) => {
+              count += countChangedFields({
+                config,
+                fields: tab.fields,
+                locales,
+                parentIsLocalized: parentIsLocalized || tab.localized,
+                valueFrom: valueFrom?.[tab.name]?.[locale],
+                valueTo: valueTo?.[tab.name]?.[locale],
+              })
+            })
+          } else if ('name' in tab) {
+            // Named tab
+            count += countChangedFields({
+              config,
+              fields: tab.fields,
+              locales,
+              parentIsLocalized: parentIsLocalized || tab.localized,
+              valueFrom: valueFrom?.[tab.name],
+              valueTo: valueTo?.[tab.name],
+            })
+          } else {
+            // Unnamed tab
+            count += countChangedFields({
+              config,
+              fields: tab.fields,
+              locales,
+              parentIsLocalized: parentIsLocalized || tab.localized,
+              valueFrom,
+              valueTo,
+            })
+          }
+        })
+        break
+      }
+
+      // UI fields don't have data and are not displayed in the version view
+      // so we can ignore them.
+      case 'ui': {
+        break
+      }
+
+      default: {
+        const _exhaustiveCheck: never = fieldType
+        throw new Error(`Unexpected field.type in countChangedFields : ${String(fieldType)}`)
+      }
+    }
+  })
+
+  return count
+}
+
+type countChangedFieldsInRowsArgs = {
+  config: ClientConfig
+  field: ArrayFieldClient | BlocksFieldClient
+  locales: string[] | undefined
+  parentIsLocalized: boolean
+  valueFromRows: unknown[]
+  valueToRows: unknown[]
+}
+
+export function countChangedFieldsInRows({
+  config,
+  field,
+  locales,
+  parentIsLocalized,
+  valueFromRows = [],
+  valueToRows = [],
+}: countChangedFieldsInRowsArgs) {
+  let count = 0
+  let i = 0
+
+  while (valueFromRows[i] || valueToRows[i]) {
+    const valueFromRow = valueFromRows?.[i] || {}
+    const valueToRow = valueToRows?.[i] || {}
+
+    const { fields: rowFields } = getFieldsForRowComparison({
+      baseVersionField: { type: 'text', fields: [], path: '', schemaPath: '' }, // Doesn't matter, as we don't need the versionFields output here
+      config,
+      field,
+      row: i,
+      valueFromRow,
+      valueToRow,
+    })
+
+    count += countChangedFields({
+      config,
+      fields: rowFields,
+      locales,
+      parentIsLocalized: parentIsLocalized || field.localized,
+      valueFrom: valueFromRow,
+      valueTo: valueToRow,
+    })
+
+    i++
+  }
+  return count
+}

--- a/packages/changes-button/src/vendor/diff/utilities/fieldHasChanges.ts
+++ b/packages/changes-button/src/vendor/diff/utilities/fieldHasChanges.ts
@@ -1,0 +1,3 @@
+export function fieldHasChanges(a: unknown, b: unknown) {
+  return JSON.stringify(a) !== JSON.stringify(b)
+}

--- a/packages/changes-button/src/vendor/diff/utilities/getFieldsForRowComparison.ts
+++ b/packages/changes-button/src/vendor/diff/utilities/getFieldsForRowComparison.ts
@@ -1,0 +1,89 @@
+import type {
+  ArrayFieldClient,
+  BaseVersionField,
+  BlocksFieldClient,
+  ClientBlock,
+  ClientConfig,
+  ClientField,
+  VersionField,
+} from 'payload'
+
+import { getUniqueListBy } from 'payload/shared'
+
+/**
+ * Get the fields for a row in an iterable field for comparison.
+ * - Array fields: the fields of the array field, because the fields are the same for each row.
+ * - Blocks fields: the union of fields from the comparison and version row,
+ *   because the fields from the version and comparison rows may differ.
+ */
+export function getFieldsForRowComparison({
+  baseVersionField,
+  config,
+  field,
+  row,
+  valueFromRow,
+  valueToRow,
+}: {
+  baseVersionField: BaseVersionField
+  config: ClientConfig
+  field: ArrayFieldClient | BlocksFieldClient
+  row: number
+  valueFromRow: any
+  valueToRow: any
+}): { fields: ClientField[]; versionFields: VersionField[] } {
+  let fields: ClientField[] = []
+  let versionFields: VersionField[] = []
+
+  if (field.type === 'array' && 'fields' in field) {
+    fields = field.fields
+    versionFields = baseVersionField.rows?.length
+      ? baseVersionField.rows[row]
+      : baseVersionField.fields
+  } else if (field.type === 'blocks') {
+    if (valueToRow?.blockType === valueFromRow?.blockType) {
+      const matchedBlock: ClientBlock =
+        config?.blocksMap?.[valueToRow?.blockType] ??
+        (((('blocks' in field || 'blockReferences' in field) &&
+          (field.blockReferences ?? field.blocks)?.find(
+            (block) => typeof block !== 'string' && block.slug === valueToRow?.blockType,
+          )) || {
+          fields: [],
+        }) as ClientBlock)
+
+      fields = matchedBlock.fields
+      versionFields = baseVersionField.rows?.length
+        ? baseVersionField.rows[row]
+        : baseVersionField.fields
+    } else {
+      const matchedVersionBlock =
+        config?.blocksMap?.[valueToRow?.blockType] ??
+        (((('blocks' in field || 'blockReferences' in field) &&
+          (field.blockReferences ?? field.blocks)?.find(
+            (block) => typeof block !== 'string' && block.slug === valueToRow?.blockType,
+          )) || {
+          fields: [],
+        }) as ClientBlock)
+
+      const matchedComparisonBlock =
+        config?.blocksMap?.[valueFromRow?.blockType] ??
+        (((('blocks' in field || 'blockReferences' in field) &&
+          (field.blockReferences ?? field.blocks)?.find(
+            (block) => typeof block !== 'string' && block.slug === valueFromRow?.blockType,
+          )) || {
+          fields: [],
+        }) as ClientBlock)
+
+      fields = getUniqueListBy<ClientField>(
+        [...matchedVersionBlock.fields, ...matchedComparisonBlock.fields],
+        'name',
+      )
+
+      // buildVersionFields already merged the fields of the version and comparison rows together
+      versionFields = baseVersionField.rows?.length
+        ? baseVersionField.rows[row]
+        : baseVersionField.fields
+    }
+  }
+
+  return { fields, versionFields }
+}

--- a/packages/changes-button/tsconfig.json
+++ b/packages/changes-button/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "composite": true, // Make sure typescript knows that this module depends on their references
+    "noEmit": false /* Do not emit outputs. */,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    "declaration": true,
+    "declarationMap": true,
+    "allowJs": true,
+    "checkJs": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "sourceMap": true,
+    "strict": false,
+    "isolatedModules": true,
+    "target": "ESNext"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/changes-button/vitest.config.mts
+++ b/packages/changes-button/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ overrides:
   '@types/react': npm:types-react@19.0.0-rc.0
   '@types/react-dom': npm:types-react-dom@19.0.0-rc.0
   undici: ^8.1.0
-  payload: 3.84.1
-  '@payloadcms/ui': 3.84.1
-  '@payloadcms/next': 3.84.1
   '@payloadcms/richtext-lexical': 3.84.1
   react: 19.1.0
   react-dom: 19.1.0
@@ -121,6 +118,25 @@ importers:
         version: 5.0.10
       typescript:
         specifier: ^5.7.3
+        version: 5.7.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
+
+  packages/changes-button:
+    dependencies:
+      dequal:
+        specifier: ^2.0.3
+        version: 2.0.3
+    devDependencies:
+      '@types/react':
+        specifier: npm:types-react@19.0.0-rc.0
+        version: types-react@19.0.0-rc.0
+      '@types/react-dom':
+        specifier: npm:types-react-dom@19.0.0-rc.0
+        version: types-react-dom@19.0.0-rc.0
+      typescript:
+        specifier: ^5.5.2
         version: 5.7.3
       vitest:
         specifier: ^3.1.2
@@ -571,6 +587,9 @@ importers:
       '@shefing/authors-info':
         specifier: workspace:*
         version: link:../packages/authors-info
+      '@shefing/changes-button':
+        specifier: workspace:*
+        version: link:../packages/changes-button
       '@shefing/color-picker':
         specifier: workspace:*
         version: link:../packages/color-picker
@@ -1742,8 +1761,8 @@ packages:
     resolution: {integrity: sha512-sTGoeZnjI8N4KS+sW2AN95gDBErhAguvkw/tWdCjeM8bvxpz5lqrnd0vOJABA1A+Ic3zED7PYoLP/RANLgVotA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  '@monaco-editor/loader@1.6.1':
-    resolution: {integrity: sha512-w3tEnj9HYEC73wtjdpR089AqkUPskFRcdkxsiSFt3SoUc3OHpmu+leP94CXBm4mHfefmhsdfI0ZQu6qJ0wgtPg==}
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
 
   '@monaco-editor/react@4.7.0':
     resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
@@ -1864,8 +1883,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.5.6':
-    resolution: {integrity: sha512-3qBGRW+sCGzgbpc5TS1a0p7eNxnOarGVQhZxfvTdnV0gFI61lX7QNtQ4V1TSREctXzYn5NetbUsLvyqwLFJM6Q==}
+  '@next/env@15.5.16':
+    resolution: {integrity: sha512-9QMKolCl+JnJtaRAQSXy4RQrhgfe8W7/G1+Hl3QSB/HZY7zQMzTwPDdTRwwio8BS96ps1MHpHhbS8qxoNV3JIQ==}
 
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
@@ -3836,8 +3855,8 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  ci-info@4.3.1:
-    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
   class-variance-authority@0.7.1:
@@ -4593,8 +4612,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -4990,8 +5009,8 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
-  immutable@4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
@@ -5948,8 +5967,8 @@ packages:
     resolution: {integrity: sha512-3cN0tCakkT4f3zo9RXDIhy6GTvtYD6bK4CRBLN9j3E/ePqN1tugAXD5rGVfoChW6s0hiek+eyYlLNqc/BG7vBQ==}
     hasBin: true
 
-  pino-std-serializers@7.0.0:
-    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
@@ -6487,8 +6506,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  sonic-boom@4.2.0:
-    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   sonner@1.7.4:
     resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
@@ -7279,8 +7298,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yaml@2.8.1:
@@ -8321,13 +8340,13 @@ snapshots:
       got: 11.8.6
       os-filter-obj: 2.0.0
 
-  '@monaco-editor/loader@1.6.1':
+  '@monaco-editor/loader@1.7.0':
     dependencies:
       state-local: 1.0.7
 
   '@monaco-editor/react@4.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@monaco-editor/loader': 1.6.1
+      '@monaco-editor/loader': 1.7.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
@@ -8414,7 +8433,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.6': {}
+  '@next/env@15.5.16': {}
 
   '@next/env@16.2.3': {}
 
@@ -10274,7 +10293,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10615,7 +10634,7 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  ci-info@4.3.1: {}
+  ci-info@4.4.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -10732,7 +10751,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   croner@10.0.1: {}
 
@@ -11826,7 +11845,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -12263,7 +12282,7 @@ snapshots:
 
   image-size@2.0.2: {}
 
-  immutable@4.3.7: {}
+  immutable@4.3.8: {}
 
   immutable@5.1.5: {}
 
@@ -13294,13 +13313,13 @@ snapshots:
 
   payload@3.84.1(graphql@16.11.0)(typescript@5.7.3):
     dependencies:
-      '@next/env': 15.5.6
+      '@next/env': 15.5.16
       '@payloadcms/translations': 3.84.1
       '@types/busboy': 1.5.4
       ajv: 8.18.0
       bson-objectid: 2.0.4
       busboy: 1.6.0
-      ci-info: 4.3.1
+      ci-info: 4.4.0
       console-table-printer: 2.12.1
       croner: 10.0.1
       dataloader: 2.2.3
@@ -13361,10 +13380,10 @@ snapshots:
       pino-abstract-transport: 2.0.0
       pump: 3.0.3
       secure-json-parse: 4.1.0
-      sonic-boom: 4.2.0
+      sonic-boom: 4.2.1
       strip-json-comments: 5.0.3
 
-  pino-std-serializers@7.0.0: {}
+  pino-std-serializers@7.1.0: {}
 
   pino@9.14.0:
     dependencies:
@@ -13372,12 +13391,12 @@ snapshots:
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.0.0
+      pino-std-serializers: 7.1.0
       process-warning: 5.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.0
+      sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
   pirates@4.0.7: {}
@@ -13807,7 +13826,7 @@ snapshots:
   sass@1.77.4:
     dependencies:
       chokidar: 3.6.0
-      immutable: 4.3.7
+      immutable: 4.3.8
       source-map-js: 1.2.1
 
   sass@1.99.0:
@@ -13988,7 +14007,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  sonic-boom@4.2.0:
+  sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -14995,7 +15014,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
   yaml@2.8.1: {}
 

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -38,6 +38,7 @@
     "@shefing/icon-select": "workspace:*",
     "@shefing/quickfilter": "workspace:*",
     "@shefing/reset-list-view": "workspace:*",
+    "@shefing/changes-button": "workspace:*",
     "@shefing/right-panel": "workspace:*",
     "cross-env": "^7.0.3",
     "dotenv": "16.4.7",

--- a/test-app/src/app/(payload)/admin/importMap.js
+++ b/test-app/src/app/(payload)/admin/importMap.js
@@ -5,6 +5,7 @@ import { default as default_0ba0d6a826c1cdb82a195f359f1d01b6 } from '@shefing/cu
 import { SelectColorFont as SelectColorFont_1c40f24ee7224375f250d2f46f89fc0b } from '@shefing/color-picker/CustomTailWindColors'
 import { SelectColorBackground as SelectColorBackground_1c40f24ee7224375f250d2f46f89fc0b } from '@shefing/color-picker/CustomTailWindColors'
 import { default as default_890511a84d4565086d474664853bee3f } from '@shefing/icon-select/selectIcons'
+import { ChangesButton as ChangesButton_b9b801cfdf1e0404dc7cf25dd920bf48 } from '@shefing/changes-button/client'
 import { default as default_4dd24e2ec1d9dc857c6d5bb6d71a585f } from '@shefing/quickfilter/QuickFilter'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
@@ -17,6 +18,7 @@ export const importMap = {
   "@shefing/color-picker/CustomTailWindColors#SelectColorFont": SelectColorFont_1c40f24ee7224375f250d2f46f89fc0b,
   "@shefing/color-picker/CustomTailWindColors#SelectColorBackground": SelectColorBackground_1c40f24ee7224375f250d2f46f89fc0b,
   "@shefing/icon-select/selectIcons#default": default_890511a84d4565086d474664853bee3f,
+  "@shefing/changes-button/client#ChangesButton": ChangesButton_b9b801cfdf1e0404dc7cf25dd920bf48,
   "@shefing/quickfilter/QuickFilter#default": default_4dd24e2ec1d9dc857c6d5bb6d71a585f,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/test-app/src/app/(payload)/layout.tsx
+++ b/test-app/src/app/(payload)/layout.tsx
@@ -4,6 +4,7 @@ import config from '@payload-config'
 import '@payloadcms/next/css'
 import type { ServerFunctionClient } from 'payload'
 import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
+import { wrapServerFunctions } from '@shefing/changes-button/server'
 import React from 'react'
 
 import { importMap } from './admin/importMap.js'
@@ -13,7 +14,7 @@ type Args = {
   children: React.ReactNode
 }
 
-const serverFunction: ServerFunctionClient = async function (args) {
+const baseServerFunction: ServerFunctionClient = async function (args) {
   'use server'
   return handleServerFunctions({
     ...args,
@@ -21,6 +22,8 @@ const serverFunction: ServerFunctionClient = async function (args) {
     importMap,
   })
 }
+
+const serverFunction: ServerFunctionClient = wrapServerFunctions(baseServerFunction)
 
 const Layout = ({ children }: Args) => (
   <RootLayout config={config} importMap={importMap} serverFunction={serverFunction}>

--- a/test-app/src/payload.config.ts
+++ b/test-app/src/payload.config.ts
@@ -17,6 +17,7 @@ import DynamicFieldOverrides from '@shefing/field-type-component-override'
 import { createIconSelectField } from '@shefing/icon-select'
 import CollectionQuickFilterPlugin from '@shefing/quickfilter'
 import { CollectionResetPreferencesPlugin } from '@shefing/reset-list-view'
+import { changesButtonPlugin } from '@shefing/changes-button'
 import RightPanelPlugin from '@shefing/right-panel'
 import { seed } from './seed'
 
@@ -140,6 +141,7 @@ export default buildConfig({
     DynamicFieldOverrides({ overrides: [] }),
     CollectionQuickFilterPlugin({ includedCollections: ['pages'] }),
     CollectionResetPreferencesPlugin({}),
+    changesButtonPlugin(),
     addAuthorsInfo({ usernameField: 'email' }),
     // RightPanelPlugin({}),
   ],

--- a/test-app/tests/e2e/changesButton.e2e.spec.ts
+++ b/test-app/tests/e2e/changesButton.e2e.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, Page } from '@playwright/test'
+import { login } from '../helpers/login'
+
+const ADMIN_USER = { email: 'admin@payload-tools.dev', password: 'Password1!' }
+const SERVER_URL = 'http://localhost:3000'
+
+/**
+ * Smoke test for the @shefing/changes-button plugin.
+ *
+ * Verifies, against the test-app `articles` collection (drafts enabled):
+ *   1. The Changes button is hidden on a freshly-opened create form (no edits yet).
+ *   2. The Changes button appears once the form is modified after publish.
+ *   3. Clicking the button opens the changes drawer with diff content.
+ *   4. The drawer can be closed.
+ *
+ * Note: Toggle (Unsaved ↔ Latest draft) and "no-changes" empty state
+ * coverage requires the upstream PR-A/PR-B APIs to be present at runtime
+ * (`@payloadcms/next/views/diff` + `config.admin.serverFunctions`). Until
+ * those ship in a release, this spec exercises only the visibility +
+ * drawer-open path which works against the plugin's static UI layer.
+ */
+test.describe('Changes button (plugin)', () => {
+  let page: Page
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext()
+    page = await context.newPage()
+    await login({ page, user: ADMIN_USER })
+  })
+
+  test('button is hidden on an unmodified create form', async () => {
+    await page.goto(`${SERVER_URL}/admin/collections/articles/create`)
+    await expect(page.locator('input[name="title"]')).toBeVisible({ timeout: 30000 })
+
+    // No edits yet → no unpublished changes → the Changes button must not render.
+    await expect(page.locator('button.changes-button, .changes-button')).toHaveCount(0)
+  })
+
+  test('button appears after the doc is published and then modified', async () => {
+    await page.goto(`${SERVER_URL}/admin/collections/articles/create`)
+    await page.fill('input[name="title"]', 'Changes-button smoke article')
+
+    // Publish.
+    await page.click('button:has-text("Publish")')
+    await expect(page.locator('.payload-toast-container').first()).toBeVisible({
+      timeout: 30000,
+    })
+
+    // Modify the form → triggers `modified === true`.
+    await page.fill('input[name="title"]', 'Changes-button smoke article (edited)')
+
+    const changesBtn = page.locator('.changes-button').first()
+    await expect(changesBtn).toBeVisible({ timeout: 15000 })
+  })
+
+  test('clicking the button opens the changes drawer', async () => {
+    const changesBtn = page.locator('.changes-button').first()
+    await changesBtn.click()
+
+    // Drawer should appear with the localized title.
+    const drawer = page.locator('[role="dialog"]', { hasText: 'Review changes' }).first()
+    await expect(drawer).toBeVisible({ timeout: 15000 })
+
+    // Close drawer (Esc) and verify it goes away.
+    await page.keyboard.press('Escape')
+    await expect(drawer).toBeHidden({ timeout: 5000 })
+  })
+})


### PR DESCRIPTION
Closes #117.

## Summary

Renames `@shefing/review-button` → `@shefing/changes-button` and refactors the plugin to follow the project's labels convention (multi-locale `labels.ts`, `useTranslation().i18n.language`-driven), matching the pattern used in `@shefing/quickfilter`.

## What changed

### Rename (folder + identifiers)

- `packages/review-button/` → `packages/changes-button/`.
- npm name: `@shefing/review-button` → `@shefing/changes-button`.
- `reviewButtonPlugin` → `changesButtonPlugin`.
- `ReviewButton` → `ChangesButton`; `ReviewDrawer` → `ChangesDrawer`; `useReviewDrawer` → `useChangesDrawer`.
- `renderReviewDiffHandler` → `renderChangesDiffHandler`; types `RenderReviewDiff*` → `RenderChangesDiff*`.
- Server-function key: `shefing/review-button:render-diff` → `shefing/changes-button:render-diff`.
- CSS BEM root: `.review-button__*` → `.changes-button__*`.
- Test file: `test-app/tests/e2e/reviewButton.e2e.spec.ts` → `changesButton.e2e.spec.ts`.

### Labels refactor

Replaced the plain `src/strings.ts` with a quickfilter-style `src/labels.ts`:

- `PLUGIN_LABELS` keyed by locale: `en`, `ar`, `es`, `fr`, `he`, `zh`.
- Keys: `changes`, `reviewChanges`, `noChangesToReview`, `failedToLoadDiff`, `toggleUnsaved`, `toggleLatestDraft`.
- `getLabel(key, locale)` helper with English fallback.
- All client components consume labels via `useTranslation().i18n.language`, so the button automatically follows the admin UI language.

### Other notable fixes carried over

- Plugin now injects at `admin.components.edit.beforeDocumentControls` (the path Payload's import-map walker and `renderDocumentSlots` actually read; the previous `.components.beforeDocumentControls` was a silent no-op).
- Dropped the `hasPublishedDoc` visibility gate so the button also appears on brand-new entities; `renderChangesDiffHandler` falls back to an empty published baseline so every populated field shows as an addition.

### Test-app

- `payload.config.ts` updated to import / register `changesButtonPlugin`.
- `(payload)/layout.tsx` updated to import `wrapServerFunctions` from `@shefing/changes-button/server`.
- `package.json` workspace dep entry renamed.
- `importMap.js` regenerated.

## Pending upstream Payload PRs

The plugin still vendors the diff pipeline and requires a `(payload)/layout.tsx` wrap because these are not yet merged:

- [payloadcms/payload#16498](https://github.com/payloadcms/payload/pull/16498) — `@payloadcms/next/views/diff` subpath export (issue: [payload#16496](https://github.com/payloadcms/payload/issues/16496)).
- [payloadcms/payload#16499](https://github.com/payloadcms/payload/pull/16499) — `config.admin.serverFunctions` registry (issue: [payload#16497](https://github.com/payloadcms/payload/issues/16497)).

Cleanup checklist for when both ship is captured in the package README under "Local development" and in #117.

## Verification

- `pnpm --filter @shefing/changes-button build` — swc 32 files + tsc declarations, ✅.
- `pnpm --filter @shefing/changes-button test` — vitest, **9/9 passed** (`ChangesButtonPlugin.test.ts` × 5, `renderChangesDiff.test.ts` × 4).
- `pnpm --filter @shefing/dev-app generate:importmap` — emits `import { ChangesButton as ... } from '@shefing/changes-button/client'`, ✅.

Playwright e2e (`changesButton.e2e.spec.ts`) was authored but not executed in this branch — runtime smoke is covered by manual verification on the test-app dev server, mirroring existing project workflow.

