### PR TITLE
Add pluggable ABAC engine for Payload

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -291,6 +291,7 @@ See [`packages/cover-image/README.md`](packages/cover-image/README.md).
 Shared improvements that benefit every plugin:
 
 - **Attribute-Based Authorization (ABAC)** — pluggable attribute providers (`geo`, `tenant`, `clearance`, …) that compile to Payload `where` clauses and merge with the existing `authorization` plugin's RBAC. One small extension point (`AttributeProvider`), no parallel permission engine. Tracking issue: [#203](https://github.com/shefing/payload-tools/issues/203).
+  - **v0.2 — Multi-value attribute support** *(next iteration)*: extend `tenantAttribute` (and the engine) to handle users that belong to **multiple values** of an attribute simultaneously (e.g. `user.tenants = ['tenant-a', 'tenant-b']`). The `toWhere` output becomes `{ tenant: { in: [...ids] } }` and `match` checks array membership. Closes the main gap vs. Payload's official `plugin-multi-tenant` which supports a `tenants[]` array per user with per-tenant roles. Also covers multi-region, multi-clearance, and any other set-valued attribute.
 - **Unified options shape** — extend every plugin's `excludedCollections` / `excludedGlobals` with `includedCollections` and `predicate: (collection) => boolean` for parity.
 - **Per-collection opt-in via `admin.custom.<pluginKey>`** documented in one place.
 - **Centralized i18n** — lift per-plugin `labels.ts` (en/ar/es/fr/he/zh) into a shared `@shefing/i18n` package.
@@ -312,6 +313,7 @@ Shared improvements that benefit every plugin:
 
 ### Wave 2 — High-value P0
 
+- ABAC: multi-value attribute support (`tenants[]` array, `{ in: [...] }` WHERE, array `match`) — closes gap vs. official `plugin-multi-tenant`.
 - Authorization: deny-list & row-level (`where`) permissions, role inheritance.
 - Comments: mentions, resolve state, document-level comments.
 - Reset List View: granular reset menu + admin-saved default view.

--- a/packages/abac/.swcrc
+++ b/packages/abac/.swcrc
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": true,
+  "jsc": {
+    "target": "esnext",
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dts": true
+    },
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  },
+  "module": {
+    "type": "es6"
+  }
+}

--- a/packages/abac/ABAC_EXPLAINED.md
+++ b/packages/abac/ABAC_EXPLAINED.md
@@ -1,0 +1,740 @@
+# ABAC Plugin — Full Explanation for Junior Developers
+
+> **What is ABAC?**
+> ABAC stands for **Attribute-Based Access Control**. Instead of just asking "what *role* does this user have?", it asks "what *attributes* does this user have, and do they match the document they're trying to access?"
+>
+> A classic example: a user belongs to **Tenant A**. With ABAC, they can only see, edit, and create documents that also belong to **Tenant A** — automatically, across every opted-in collection, without you writing a single custom `access` function.
+
+---
+
+## Table of Contents
+
+1. [The Big Picture — How It All Fits Together](#1-the-big-picture)
+2. [The Contract — `types.ts`](#2-the-contract--typests)
+3. [The Engine — `compile.ts` and `enrichJWT.ts`](#3-the-engine)
+4. [Built-in Providers — `tenant.ts` and `role.ts`](#4-built-in-providers)
+5. [Plugin Wiring — `index.ts`](#5-plugin-wiring--indexts)
+6. [The Permissions Endpoint — `mePermissions.ts`](#6-the-permissions-endpoint)
+7. [The Filter Helper — `filterOptions.ts`](#7-the-filter-helper)
+8. [The Provider Registry — `pluginContext.ts`](#8-the-provider-registry)
+9. [How to Use the Plugin (Developer Guide)](#9-how-to-use-the-plugin-developer-guide)
+10. [What the End User Experiences](#10-what-the-end-user-experiences)
+11. [Edge Cases and Safety Nets](#11-edge-cases-and-safety-nets)
+12. [File Map at a Glance](#12-file-map-at-a-glance)
+
+---
+
+## 1. The Big Picture
+
+Imagine your Payload CMS app has **articles** that belong to different tenants (companies). You want:
+
+- Alice (Tenant A) → can only see/edit/create Tenant A articles
+- Bob (Tenant B) → can only see/edit/create Tenant B articles
+- Admin → can see everything
+
+Without this plugin, you'd write a custom `access.read` function on the `articles` collection, then repeat it for `access.update`, `access.delete`, and `access.create`. Then do the same for every other collection. That's a lot of copy-paste.
+
+**With `@shefing/abac`**, you:
+1. Register a `tenantAttribute` provider once.
+2. Opt each collection in with one line of config.
+3. The plugin automatically enforces access everywhere.
+
+Here's the flow when Alice requests `GET /api/articles`:
+
+```
+Alice's request
+    │
+    ▼
+Payload calls access.read()
+    │
+    ▼
+abacPlugin intercepts → asks: "what is Alice's tenant?" → "tenant-a"
+    │
+    ▼
+Engine builds a WHERE clause: { tenant: { equals: "tenant-a" } }
+    │
+    ▼
+Database query runs with that filter → only Tenant A articles come back
+    │
+    ▼
+Alice sees only her articles ✓
+```
+
+---
+
+## 2. The Contract — `types.ts`
+
+This file defines the **shapes** (TypeScript types) that everything else in the plugin uses. Think of it as the rulebook.
+
+### `AttributeProvider<UserValue, DocumentValue>`
+
+This is the **most important type** in the whole package. It is the interface every provider must implement.
+
+```ts
+export type AttributeProvider<UserValue = unknown, DocumentValue = unknown> = {
+  key: string
+  fromUser(user, req): UserValue | Promise<UserValue>
+  fromDoc?: { [collectionSlug]: (doc) => DocumentValue }
+  match(userValue, docValue): boolean | Promise<boolean>
+  toWhere?(userValue): Where
+  enrichJWT?(user): Record<string, unknown> | Promise<Record<string, unknown>>
+}
+```
+
+| Field | What it does | Required? |
+|---|---|---|
+| `key` | A unique name for this provider, e.g. `"tenant"` | ✅ Yes |
+| `fromUser` | Reads the relevant attribute off the logged-in user, e.g. `user.tenant` | ✅ Yes |
+| `fromDoc` | Reads the relevant attribute off a document (per collection). Falls back to `docField` path if omitted. | ❌ Optional |
+| `match` | Returns `true` if the user's value matches the document's value. Used for `create` checks. | ✅ Yes |
+| `toWhere` | Converts the user's value into a Payload `where` filter for DB-level filtering. Used for `read/update/delete`. | ❌ Optional (but recommended) |
+| `enrichJWT` | Adds extra data to the user's JWT token at login time, so it's available on every request without a DB call. | ❌ Optional |
+
+### `AbacCollectionConfig`
+
+This is what you put in a collection's `custom.abac` field to opt it in:
+
+```ts
+// Example: opt the "articles" collection into tenant-based access
+custom: {
+  abac: {
+    tenant: {           // ← must match a registered provider's key
+      docField: 'tenant', // ← the field on the article document
+      stampOnCreate: true, // ← auto-fill tenant on new docs (default: true)
+      actions: ['read', 'update', 'delete', 'create'], // ← which actions to guard
+    }
+  }
+}
+```
+
+### `AbacPluginConfig`
+
+What you pass to `abacPlugin(...)`:
+
+```ts
+export type AbacPluginConfig = {
+  attributes: AttributeProvider[]      // list of providers to register
+  excludedCollections?: CollectionSlug[] // collections to skip entirely
+  includedCollections?: CollectionSlug[] // if set, only these are considered
+  policies?: unknown                   // reserved for future use, ignored in v1
+}
+```
+
+### `AbacPermissionsResponse`
+
+The shape returned by `GET /api/me/permissions?collection=articles`:
+
+```ts
+{
+  collection: 'articles',
+  where: { tenant: { equals: 'tenant-a' } }, // or null if no constraints
+  actions: ['read', 'update', 'delete', 'create']
+}
+```
+
+---
+
+## 3. The Engine
+
+The engine is the **brain** of the plugin. It is made of pure functions — no Payload imports, no side effects — which makes it easy to unit-test.
+
+### `compile.ts` — Building WHERE clauses and create decisions
+
+#### Helper: `hasValue(value)`
+
+```ts
+const hasValue = (value: unknown): boolean => {
+  if (Array.isArray(value)) return value.length > 0
+  return value !== null && value !== undefined
+}
+```
+
+Simple utility: returns `false` for `null`, `undefined`, and empty arrays. Used to detect "this user has no attribute value" → deny access.
+
+#### Helper: `normalizeValue(value)`
+
+Payload relationship fields can be either a raw ID (`"abc123"`) or a full object (`{ id: "abc123", name: "Tenant A" }`). This function always extracts just the ID so comparisons work correctly regardless of how Payload populated the field.
+
+#### Helper: `getValueAtPath(doc, path)`
+
+Reads a nested value from a document using a dot-notation path. For example, `getValueAtPath(doc, 'meta.tenant')` reads `doc.meta.tenant`.
+
+#### `EMPTY_RESULTS_WHERE`
+
+```ts
+const EMPTY_RESULTS_WHERE: Where = { id: { exists: false } }
+```
+
+A special WHERE clause that matches **no documents**. Used when a user has no attribute value — instead of returning all docs (dangerous!), the engine returns this filter so the DB returns an empty list.
+
+#### `compileWhere(providers, user, action, req)` → `Where | true | false`
+
+This is the core function for **read, update, and delete** access. It:
+
+1. Returns `false` immediately if there is no logged-in user.
+2. Returns `true` immediately if the user is an admin (`user.isAdmin === true`) — admins bypass all ABAC.
+3. Loops through every registered provider for this collection:
+   - Skips providers that don't apply to this action.
+   - Calls `provider.fromUser(user)` to get the user's attribute value.
+   - If the user has **no value** → returns `EMPTY_RESULTS_WHERE` (empty list, not all docs).
+   - If the provider has `toWhere` → collects the resulting WHERE clause.
+4. Merges all WHERE clauses with `{ and: [...] }`.
+5. Returns `true` if no providers produced a WHERE (no constraints needed).
+
+**Example result for Alice with tenant-a:**
+```ts
+// Single provider → returns the where directly
+{ tenant: { equals: 'tenant-a' } }
+
+// Two providers (tenant + clearance) → AND-merged
+{ and: [
+  { tenant: { equals: 'tenant-a' } },
+  { clearanceLevel: { less_than_equal: 3 } }
+]}
+```
+
+#### `decideCreate(providers, user, data, req)` → `boolean`
+
+Used for **create** access. Instead of building a WHERE clause (there's no existing document to filter), it checks whether the data the user is trying to save matches their attributes:
+
+1. Returns `false` if no user.
+2. Returns `true` if admin.
+3. For each provider:
+   - Gets the user's attribute value.
+   - Gets the document's attribute value from the submitted `data`.
+   - Calls `provider.match(userValue, docValue)`.
+   - If `match` returns `false` → deny the create.
+4. Returns `true` only if **all** providers approve.
+
+**Example:** Alice (tenant-a) tries to create an article with `tenant: "tenant-b"` → `match("tenant-a", "tenant-b")` returns `false` → create is rejected.
+
+#### Fail-closed safety
+
+```ts
+} catch (error) {
+  return warnAndReturn(error, false)
+}
+```
+
+If any provider throws an error, the engine **denies access** and logs a warning. It never accidentally grants access due to a bug.
+
+---
+
+### `enrichJWT.ts` — Caching attributes in the JWT
+
+```ts
+export const enrichJWT = async (providers, user) => {
+  const enrichedPayload = {}
+  for (const provider of providers) {
+    if (!provider.enrichJWT) continue
+    const nextPayload = await provider.enrichJWT(user)
+    for (const [key, value] of Object.entries(nextPayload)) {
+      if (key in enrichedPayload) {
+        console.warn(`[abac] enrichJWT key collision for "${key}", last value wins`)
+      }
+      enrichedPayload[key] = value
+    }
+  }
+  return enrichedPayload
+}
+```
+
+**Why does this exist?** Every time a user makes a request, the plugin needs to know their attributes (e.g. their tenant). Without this, it would need a DB query on every single request. Instead, at **login time**, this function runs all providers' `enrichJWT` methods and merges the results into the JWT token. From then on, `req.user.tenant` is available instantly from the token — zero extra DB queries.
+
+**Key collision warning:** If two providers try to write the same key (e.g. both write `tenant`), the last one wins and a warning is logged in development.
+
+---
+
+## 4. Built-in Providers
+
+### `tenant.ts` — The Tenant Provider
+
+```ts
+export const tenantAttribute = ({
+  userField = 'tenant',
+  docField = 'tenant',
+  jwtKey = userField,
+} = {}): AttributeProvider => ({
+  key: 'tenant',
+  fromUser: async (user) => normalizeRelationshipValue(getValueAtPath(user, userField) ?? null),
+  match: (userValue, docValue) => userValue != null && userValue === docValue,
+  toWhere: (userValue) => ({ [docField]: { equals: userValue } }),
+  enrichJWT: async (user) => ({ [jwtKey]: normalizeRelationshipValue(getValueAtPath(user, userField) ?? null) }),
+})
+```
+
+This is the most commonly used built-in. It:
+
+- **`fromUser`**: reads `user.tenant` (or whatever `userField` you configure) and normalizes it to a plain ID.
+- **`match`**: checks if the user's tenant ID equals the document's tenant ID. Simple equality check.
+- **`toWhere`**: produces `{ tenant: { equals: "tenant-a" } }` — a Payload WHERE clause that the DB uses to filter.
+- **`enrichJWT`**: at login, copies the user's tenant ID into the JWT so it's available on every request.
+
+**Configuration options:**
+| Option | Default | Meaning |
+|---|---|---|
+| `userField` | `'tenant'` | Path on the user object to read the tenant from |
+| `docField` | `'tenant'` | Field on the document to filter/compare against |
+| `jwtKey` | same as `userField` | Key to use when writing to the JWT |
+
+---
+
+### `role.ts` — The Role Bridge Provider
+
+```ts
+export const roleAttribute = (): AttributeProvider<RoleValue, unknown> => ({
+  key: 'role',
+  fromUser: async (user) => ({
+    isAdmin: Boolean(user.isAdmin),
+    roleIds: getRoleIds(user),
+  }),
+  match: (userValue) => {
+    if (userValue.isAdmin) return true
+    return userValue.roleIds.length > 0
+  },
+  enrichJWT: async (user) => ({
+    userRoles: Array.isArray(user.userRoles) ? user.userRoles : [],
+    isAdmin: Boolean(user.isAdmin),
+  }),
+})
+```
+
+This provider bridges ABAC with the existing `@shefing/authorization` RBAC plugin. It:
+
+- **`fromUser`**: reads `user.isAdmin` and `user.userRoles` (the role IDs from the RBAC plugin).
+- **`match`**: allows access if the user is an admin OR has at least one role. It does **not** do row-level filtering (no `toWhere`) — RBAC is a yes/no gate, not a row filter.
+- **`enrichJWT`**: ensures `userRoles` and `isAdmin` are always present in the JWT.
+
+> **Note for developers:** `roleAttribute` has no `toWhere`. This means it only participates in `create` decisions (via `match`), not in WHERE-clause filtering. If you use only `roleAttribute`, all rows pass the WHERE filter — the role check is a boolean gate on top.
+
+---
+
+## 5. Plugin Wiring — `index.ts`
+
+This is the **entry point** of the plugin. It's a function that takes your config and returns a function that transforms Payload's config. This is the standard Payload plugin pattern.
+
+```ts
+export const abacPlugin = (pluginConfig: AbacPluginConfig) => (incomingConfig: Config): Config => {
+  // ...
+}
+```
+
+### Step 1: Register providers
+
+```ts
+registerProviders(pluginConfig.attributes)
+const providersByKey = new Map(pluginConfig.attributes.map((p) => [p.key, p]))
+```
+
+Stores all providers in a global registry (for use by `abacFilterOptions`) and in a local Map for fast lookup by key.
+
+### Step 2: Process each collection
+
+For each collection in Payload's config:
+
+1. **Skip** if the collection is excluded or not included per `includedCollections`/`excludedCollections`.
+2. **Skip** if the collection has no `custom.abac` config.
+3. **Validate** that every key in `custom.abac` matches a registered provider — throws a clear error at startup if not.
+4. **Build `resolvedProviders`**: pairs each provider with its per-collection config (docField, actions, stampOnCreate).
+
+### Step 3: Compose access functions
+
+```ts
+nextCollection.access = {
+  read:   composeAccess(previousAccess.read,   async (req) => compileWhere(resolvedProviders, req.user, 'read',   req)),
+  update: composeAccess(previousAccess.update, async (req) => compileWhere(resolvedProviders, req.user, 'update', req)),
+  delete: composeAccess(previousAccess.delete, async (req) => compileWhere(resolvedProviders, req.user, 'delete', req)),
+  create: composeAccess(previousAccess.create, async (req, data) => (await decideCreate(...)) ? true : false),
+}
+```
+
+`composeAccess` is the key function here. It **wraps** the existing access function (if any) rather than replacing it:
+
+```ts
+const composeAccess = (previousAccess, computeAccess) => async ({ data, req }) => {
+  const previousResult = previousAccess ? await previousAccess({ data, req }) : true
+  const nextResult = await computeAccess(req, data)
+  return andAccessResults(previousResult, nextResult)
+}
+```
+
+`andAccessResults` combines two access results with AND logic:
+- If either is `false` → `false` (deny wins)
+- If left is `true` → use right (no constraint from left)
+- If right is `true` → use left
+- If both are WHERE objects → `{ and: [left, right] }`
+
+This means **ABAC never overrides existing access rules — it only narrows them further**.
+
+### Step 4: Add `beforeChange` hook (auto-stamp)
+
+```ts
+const beforeChange = async ({ data, operation, req }) => {
+  if (operation !== 'create' || !req.user) return data
+  // For each provider, if the doc field is empty, fill it from the user's attribute
+  for (const resolvedProvider of resolvedProviders) {
+    if (resolvedProvider.config.stampOnCreate === false) continue
+    const existingValue = getPathValue(nextData, resolvedProvider.config.docField)
+    if (hasValue(existingValue)) continue
+    const userValue = await resolvedProvider.provider.fromUser(req.user, req)
+    if (hasValue(userValue)) setPathValue(nextData, resolvedProvider.config.docField, userValue)
+  }
+  return nextData
+}
+```
+
+When Alice creates a new article and doesn't specify a tenant, this hook automatically sets `article.tenant = alice.tenant`. This prevents Alice from accidentally creating untagged documents.
+
+### Step 5: Add `afterLogin` hook (JWT enrichment)
+
+```ts
+if (nextCollection.auth) {
+  const afterLogin = async ({ req, user }) => {
+    req.user = { ...req.user, ...user, ...(await enrichJWT(pluginConfig.attributes, user)) }
+  }
+  nextCollection.hooks.afterLogin = [afterLogin, ...]
+}
+```
+
+Only runs on collections that have `auth: true` (i.e. the Users collection). After a successful login, it merges all providers' `enrichJWT` output into `req.user`, which Payload then encodes into the JWT token.
+
+### Step 6: Register the `/api/me/permissions` endpoint
+
+```ts
+const endpoint = createMePermissionsEndpoint({
+  getProvidersForCollection: (slug) => collectionProviderMap.get(slug)?.providers ?? [],
+  isCollectionEnabled: (slug) => collectionProviderMap.has(slug),
+})
+```
+
+Adds a single root-level endpoint that any client can call to discover what access the current user has.
+
+---
+
+## 6. The Permissions Endpoint
+
+**File:** `src/endpoints/mePermissions.ts`
+
+**URL:** `GET /api/me/permissions?collection=articles`
+
+**What it does:** Returns the compiled WHERE clause and allowed actions for the current user on a given collection. Useful for frontend apps that need to mirror server-side access rules (e.g. pre-filtering a dropdown).
+
+```ts
+// Example response for Alice (tenant-a):
+{
+  "collection": "articles",
+  "where": { "tenant": { "equals": "tenant-a" } },
+  "actions": ["read", "update", "delete", "create"]
+}
+
+// Example response for an unauthenticated user:
+// HTTP 403 { "message": "Unauthorized" }
+
+// Example response for a collection not opted into ABAC:
+// HTTP 404 { "message": "Collection \"users\" is not ABAC-enabled" }
+```
+
+**How it works internally:**
+1. Checks the user is logged in (403 if not).
+2. Reads the `?collection=` query parameter (400 if missing).
+3. Checks the collection is ABAC-enabled (404 if not).
+4. Runs `compileWhere` for all four actions (`read`, `create`, `update`, `delete`).
+5. The `where` in the response is the result for `read` (converted to `null` if it's `true` or `false`).
+6. The `actions` list contains every action that didn't return `false`.
+
+---
+
+## 7. The Filter Helper
+
+**File:** `src/helpers/filterOptions.ts`
+
+**What it does:** Pre-filters relationship dropdowns in the Payload admin UI so users only see options they're allowed to pick.
+
+**Usage in a collection field:**
+```ts
+{
+  name: 'tenant',
+  type: 'relationship',
+  relationTo: 'tenants',
+  filterOptions: abacFilterOptions('tenant'), // ← one line!
+}
+```
+
+**How it works:**
+```ts
+export const abacFilterOptions = (key: string) => {
+  return async ({ req }) => {
+    const provider = getRegisteredProvider(key)
+    if (!provider || !provider.toWhere || !req.user) return true
+    const userValue = await provider.fromUser(req.user, req)
+    if (!hasValue(userValue)) return false
+    return provider.toWhere(userValue)
+  }
+}
+```
+
+- Looks up the provider by key from the global registry.
+- If the provider has no `toWhere` or the user has no value → returns `true` (no filter) or `false` (no options).
+- Otherwise returns the WHERE clause so the dropdown only shows matching options.
+
+**Result:** When Alice opens the "Tenant" dropdown while creating an article, she only sees "Tenant A" — not all tenants.
+
+---
+
+## 8. The Provider Registry
+
+**File:** `src/pluginContext.ts`
+
+```ts
+const providerRegistry = new Map<string, AttributeProvider>()
+
+export const registerProviders = (providers: AttributeProvider[]): void => {
+  providerRegistry.clear()
+  for (const provider of providers) {
+    providerRegistry.set(provider.key, provider)
+  }
+}
+
+export const getRegisteredProvider = (key: string): AttributeProvider | undefined => {
+  return providerRegistry.get(key)
+}
+```
+
+A simple module-level Map that acts as a global registry. It's populated once when `abacPlugin` runs (at Payload startup). The `abacFilterOptions` helper uses `getRegisteredProvider` to look up providers without needing them passed as arguments.
+
+> **Why a global registry?** Payload's `filterOptions` function only receives `{ req }` — there's no way to pass extra context. The registry solves this by making providers accessible globally within the process.
+
+---
+
+## 9. How to Use the Plugin (Developer Guide)
+
+### Installation
+
+```bash
+pnpm add @shefing/abac
+```
+
+### Step 1: Register the plugin in `payload.config.ts`
+
+```ts
+import { abacPlugin, tenantAttribute, roleAttribute } from '@shefing/abac'
+
+export default buildConfig({
+  plugins: [
+    abacPlugin({
+      attributes: [
+        tenantAttribute(),  // built-in: tenant-based row filtering
+        roleAttribute(),    // built-in: bridges with @shefing/authorization
+      ],
+      // Optional: skip these collections entirely
+      excludedCollections: ['media'],
+    }),
+  ],
+  // ...
+})
+```
+
+### Step 2: Add a `tenant` field to your Users collection
+
+```ts
+{
+  name: 'tenant',
+  type: 'relationship',
+  relationTo: 'tenants',
+  saveToJWT: true, // ← IMPORTANT: makes it available on req.user without a DB call
+}
+```
+
+### Step 3: Opt a collection into ABAC
+
+```ts
+{
+  slug: 'articles',
+  custom: {
+    abac: {
+      tenant: {              // ← must match a registered provider's key
+        docField: 'tenant',  // ← the field on the article document
+        stampOnCreate: true, // ← auto-fill tenant when creating (default: true)
+      },
+    },
+  },
+  fields: [
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      filterOptions: abacFilterOptions('tenant'), // ← pre-filter the dropdown
+    },
+    // ... other fields
+  ],
+}
+```
+
+### Step 4: That's it!
+
+Now:
+- `GET /api/articles` → automatically filtered to the user's tenant
+- `POST /api/articles` → rejected if the tenant doesn't match (or auto-stamped if missing)
+- `PATCH /api/articles/:id` → rejected if the article belongs to a different tenant
+- `DELETE /api/articles/:id` → rejected if the article belongs to a different tenant
+- `GET /api/me/permissions?collection=articles` → returns the user's WHERE + allowed actions
+
+### Writing a Custom Provider
+
+You can write your own provider for any attribute. Here's a clearance level example:
+
+```ts
+import type { AttributeProvider } from '@shefing/abac'
+
+export const clearanceAttribute = (): AttributeProvider<number, number> => ({
+  key: 'clearance',
+  fromUser: async (user) => (user.clearanceLevel as number) ?? 0,
+  match: (userValue, docValue) => userValue >= docValue,
+  toWhere: (userValue) => ({ clearanceLevel: { less_than_equal: userValue } }),
+  enrichJWT: async (user) => ({ clearanceLevel: user.clearanceLevel ?? 0 }),
+})
+```
+
+Then register it:
+```ts
+abacPlugin({
+  attributes: [tenantAttribute(), clearanceAttribute()],
+})
+```
+
+And opt a collection in:
+```ts
+custom: {
+  abac: {
+    tenant: { docField: 'tenant' },
+    clearance: { docField: 'clearanceLevel', stampOnCreate: false },
+  }
+}
+```
+
+Both providers are AND-ed together: the user must match **both** tenant AND clearance level.
+
+### Combining with `@shefing/authorization` (RBAC)
+
+Both plugins compose safely. Register `addAccess` first, then `abacPlugin`:
+
+```ts
+plugins: [
+  addAccess({ ... }),   // RBAC: role-based yes/no gate
+  abacPlugin({ ... }),  // ABAC: narrows further with attribute filters
+]
+```
+
+`composeAccess` ensures ABAC wraps whatever access function RBAC already set. If RBAC denies → denied. If RBAC allows → ABAC applies its WHERE filter on top.
+
+---
+
+## 10. What the End User Experiences
+
+### Logging in
+
+When Alice logs in via `POST /api/users/login`:
+1. Payload authenticates her credentials.
+2. The `afterLogin` hook runs `enrichJWT` for all providers.
+3. Her JWT now contains `{ tenant: "tenant-a-id", userRoles: [...], isAdmin: false }`.
+4. Every subsequent request uses this JWT — no extra DB calls needed.
+
+### Browsing the articles list
+
+Alice navigates to `/admin/collections/articles`:
+1. The admin UI calls `GET /api/articles`.
+2. Payload calls `access.read()` on the articles collection.
+3. The ABAC engine reads `req.user.tenant` → `"tenant-a-id"`.
+4. Engine returns `{ tenant: { equals: "tenant-a-id" } }`.
+5. Payload adds this to the DB query.
+6. Alice sees only Tenant A articles.
+
+### Creating a new article
+
+Alice clicks "Create Article":
+1. The tenant dropdown shows only "Tenant A" (thanks to `abacFilterOptions`).
+2. Alice submits the form.
+3. The `beforeChange` hook runs: if she didn't pick a tenant, it auto-fills `tenant-a-id`.
+4. `access.create()` runs `decideCreate`: checks `match("tenant-a-id", "tenant-a-id")` → `true`.
+5. Article is created successfully.
+
+### Trying to access another tenant's article
+
+Bob tries `GET /api/articles/alice-article-id`:
+1. `access.read()` returns `{ tenant: { equals: "tenant-b-id" } }`.
+2. Payload queries the DB with that filter.
+3. Alice's article (tenant-a) doesn't match → not found / 404.
+
+### Frontend app checking permissions
+
+A React frontend calls `GET /api/me/permissions?collection=articles`:
+```json
+{
+  "collection": "articles",
+  "where": { "tenant": { "equals": "tenant-a-id" } },
+  "actions": ["read", "create", "update", "delete"]
+}
+```
+The frontend can use this `where` to pre-filter its own queries and show/hide UI elements based on `actions`.
+
+---
+
+## 11. Edge Cases and Safety Nets
+
+| Situation | What happens |
+|---|---|
+| User is not logged in | Engine returns `false` → Payload returns 403 |
+| User has no tenant value | Engine returns `{ id: { exists: false } }` → empty list (not all docs!) |
+| User is an admin (`isAdmin: true`) | Engine returns `true` → no filtering, sees everything |
+| Provider throws an error | Engine catches it, logs a warning, **denies access** (fail-closed) |
+| Provider key in `custom.abac` not registered | Plugin throws at startup with a clear error message |
+| Two providers write the same JWT key | Last one wins, a warning is logged |
+| Collection has no `custom.abac` | Plugin is a complete no-op for that collection |
+| `stampOnCreate: false` | Auto-stamping is skipped; user must provide the field value manually |
+| `toWhere` returns an `or` clause | Still safely composed under the outer `and` |
+
+---
+
+## 12. File Map at a Glance
+
+```
+packages/abac/src/
+│
+├── types.ts                  ← All TypeScript types (AttributeProvider, AbacPluginConfig, etc.)
+│
+├── index.ts                  ← Main plugin entry: abacPlugin() function + all exports
+│
+├── pluginContext.ts           ← Global provider registry (Map<key, provider>)
+│
+├── engine/
+│   ├── compile.ts            ← compileWhere() and decideCreate() — the core logic
+│   └── enrichJWT.ts          ← Merges all providers' JWT enrichments at login
+│
+├── providers/
+│   ├── tenant.ts             ← Built-in: tenant-based row filtering
+│   └── role.ts               ← Built-in: bridges with @shefing/authorization RBAC
+│
+├── endpoints/
+│   └── mePermissions.ts      ← GET /api/me/permissions handler
+│
+└── helpers/
+    └── filterOptions.ts      ← abacFilterOptions() for relationship field dropdowns
+```
+
+### Data flow summary
+
+```
+Login
+  └─► afterLogin hook ──► enrichJWT() ──► JWT token (tenant, roles, etc.)
+
+Every request
+  └─► access.read/update/delete ──► compileWhere() ──► WHERE clause ──► DB filter
+  └─► access.create ──────────────► decideCreate() ──► boolean allow/deny
+  └─► beforeChange hook ──────────► auto-stamp missing fields from user attrs
+
+Admin UI relationship dropdown
+  └─► filterOptions ──► abacFilterOptions() ──► WHERE clause ──► filtered options
+
+Frontend permission check
+  └─► GET /api/me/permissions ──► compileWhere() for all actions ──► { where, actions }
+```

--- a/packages/abac/README.md
+++ b/packages/abac/README.md
@@ -1,0 +1,79 @@
+## [ABAC Plugin](./src/index.ts)
+
+`@shefing/abac` adds a pluggable, Payload-native attribute-based access control layer.
+
+### Goals
+
+- Keep the implementation simple and Payload-first.
+- Compile attributes into Payload `where` clauses whenever possible.
+- Reuse JWT-enriched user data instead of introducing a parallel permission store.
+
+### Install
+
+`pnpm add @shefing/abac`
+
+### Core contract
+
+```ts
+import type { AttributeProvider } from '@shefing/abac'
+
+const tenantAttribute: AttributeProvider<string | null> = {
+  key: 'tenant',
+  fromUser: (user) => (typeof user.tenant === 'string' ? user.tenant : null),
+  match: (userValue, docValue) => userValue != null && userValue === docValue,
+  toWhere: (userValue) => ({ tenant: { equals: userValue } }),
+  enrichJWT: (user) => ({ tenant: user.tenant ?? null }),
+}
+```
+
+### Tenant example
+
+```ts
+import { abacPlugin } from '@shefing/abac'
+
+plugins: [
+  abacPlugin({
+    attributes: [
+      {
+        key: 'tenant',
+        fromUser: (user) => user.tenant,
+        match: (userValue, docValue) => userValue === docValue,
+        toWhere: (userValue) => ({ tenant: { equals: userValue } }),
+        enrichJWT: (user) => ({ tenant: user.tenant }),
+      },
+    ],
+  }),
+]
+```
+
+Then opt collections in with `custom.abac`:
+
+```ts
+custom: {
+  abac: {
+    tenant: {
+      docField: 'tenant',
+    },
+  },
+}
+```
+
+### Geo example
+
+`geo` is intentionally documented as an example for v1 rather than shipped as a built-in:
+
+```ts
+const geoAttribute = {
+  key: 'geo',
+  fromUser: (user) => user.region,
+  match: (userRegion, docRegion) => userRegion === docRegion,
+  toWhere: (userRegion) => ({ region: { equals: userRegion } }),
+}
+```
+
+### Notes
+
+- v1 keeps policy composition simple: matching providers are combined with implicit `AND`.
+- Built-in `tenantAttribute()` and `roleAttribute()` are exported from the package entry.
+- `roleAttribute()` is additive with `@shefing/authorization`: it preserves JWT role context and can short-circuit admins, but it does not replace RBAC collection permissions.
+- See the integration coverage in `test-app/tests/e2e-plugins/abac.spec.ts` once the feature is fully wired.

--- a/packages/abac/README.md
+++ b/packages/abac/README.md
@@ -71,9 +71,52 @@ const geoAttribute = {
 }
 ```
 
+### Multi-value attributes (v0.2 — coming next)
+
+> **Current limitation (v1):** each attribute provider resolves to a **single value** per user (e.g. `user.tenant = 'tenant-a'`). If a user belongs to multiple tenants the engine only sees the first one.
+
+The v0.2 milestone will extend the engine and `tenantAttribute` to handle **array-valued** attributes natively:
+
+```ts
+// user.tenants = ['tenant-a', 'tenant-b']  ← multiple memberships
+
+const multiTenantAttribute = {
+  key: 'tenant',
+  fromUser: (user) => Array.isArray(user.tenants) ? user.tenants : [],
+  match: (userTenants, docTenant) =>
+    Array.isArray(userTenants) && userTenants.includes(docTenant as string),
+  // toWhere will emit { tenant: { in: ['tenant-a', 'tenant-b'] } }
+  toWhere: (userTenants) => ({ tenant: { in: userTenants as string[] } }),
+  enrichJWT: (user) => ({ tenants: Array.isArray(user.tenants) ? user.tenants : [] }),
+}
+```
+
+This closes the main gap vs. Payload's official `plugin-multi-tenant`, which stores a `tenants[]` array per user. The same pattern applies to any set-valued attribute (multi-region, multi-clearance, etc.).
+
+---
+
 ### Notes
 
 - v1 keeps policy composition simple: matching providers are combined with implicit `AND`.
 - Built-in `tenantAttribute()` and `roleAttribute()` are exported from the package entry.
 - `roleAttribute()` is additive with `@shefing/authorization`: it preserves JWT role context and can short-circuit admins, but it does not replace RBAC collection permissions.
 - See the integration coverage in `test-app/tests/e2e-plugins/abac.spec.ts` once the feature is fully wired.
+
+---
+
+### Roadmap
+
+| Version | Item | Status |
+|---------|------|--------|
+| v1 | Single-value attribute providers (`tenant`, `role`, custom) | ✅ Shipped |
+| v1 | JWT enrichment — zero extra DB queries per request | ✅ Shipped |
+| v1 | `GET /api/me/permissions` endpoint | ✅ Shipped |
+| v1 | `abacFilterOptions` relationship field helper | ✅ Shipped |
+| v1 | Fail-closed safety + startup config validation | ✅ Shipped |
+| **v0.2** | **Multi-value attribute support** (`tenants[]`, `{ in: [...] }` WHERE, array `match`) | 🔜 Next |
+| v0.2 | `readVersions` / `unlock` action guards | 🔜 Next |
+| v0.2 | `pluginContext` singleton → closure (test isolation) | 🔜 Next |
+| v0.3 | Optional admin UI: tenant switcher component | 💡 Planned |
+| v0.3 | `isGlobal` collection mode (per-tenant globals) | 💡 Planned |
+| v0.3 | Per-tenant roles (`tenantRoleAttribute`) | 💡 Planned |
+| v0.3 | i18n support | 💡 Planned |

--- a/packages/abac/package.json
+++ b/packages/abac/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@shefing/abac",
+  "version": "0.0.1",
+  "private": false,
+  "bugs": "https://github.com/shefing/payload-tools/issues",
+  "repository": "https://github.com/shefing/payload-tools",
+  "license": "MIT",
+  "author": "shefing",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
+    "build:swc": "swc ./src -d ./dist --config-file .swcrc",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
+    "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
+    "lint": "eslint src",
+    "lint:fix": "eslint --fix --ext .ts,.tsx src",
+    "prepublishOnly": "pnpm clean && pnpm build",
+    "reinstall": "rm -rf node_modules .next && rm -rf .next && rm pnpm-lock.yaml  && pnpm install",
+    "test": "vitest run --config ./vitest.config.mts"
+  },
+  "peerDependencies": {
+    "payload": ">=3.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.2",
+    "vitest": "^3.2.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/abac/src/endpoints/mePermissions.ts
+++ b/packages/abac/src/endpoints/mePermissions.ts
@@ -1,0 +1,63 @@
+import type { Endpoint, PayloadHandler, Where } from 'payload'
+
+import { compileWhere } from '../engine/compile.js'
+import type { AbacAction, AbacPermissionsResponse, ResolvedProvider } from '../types.js'
+
+const ACTIONS: AbacAction[] = ['read', 'create', 'update', 'delete']
+
+type EndpointOptions = {
+  getProvidersForCollection: (slug: string) => ResolvedProvider[]
+  isCollectionEnabled: (slug: string) => boolean
+}
+
+const toJson = (body: unknown, status = 200): Response => {
+  return Response.json(body, { status })
+}
+
+export const createMePermissionsHandler = ({
+  getProvidersForCollection,
+  isCollectionEnabled,
+}: EndpointOptions): PayloadHandler => {
+  return async (req) => {
+    if (!req.user) {
+      return toJson({ message: 'Unauthorized' }, 403)
+    }
+
+    const slug = req.searchParams.get('collection')
+
+    if (!slug) {
+      return toJson({ message: 'Missing collection query parameter' }, 400)
+    }
+
+    if (!isCollectionEnabled(slug)) {
+      return toJson({ message: `Collection "${slug}" is not ABAC-enabled` }, 404)
+    }
+
+    const providers = getProvidersForCollection(slug)
+    const whereByAction = await Promise.all(
+      ACTIONS.map(async (action) => ({
+        action,
+        result: await compileWhere(providers, req.user, action, req),
+      })),
+    )
+
+    const readWhere = whereByAction.find(({ action }) => action === 'read')?.result
+    const actions = whereByAction
+      .filter(({ result }) => result !== false)
+      .map(({ action }) => action)
+
+    const response: AbacPermissionsResponse = {
+      collection: slug,
+      where: readWhere === true || readWhere === false ? null : (readWhere as Where),
+      actions,
+    }
+
+    return toJson(response)
+  }
+}
+
+export const createMePermissionsEndpoint = (options: EndpointOptions): Endpoint => ({
+  method: 'get',
+  path: '/me/permissions',
+  handler: createMePermissionsHandler(options),
+})

--- a/packages/abac/src/engine/compile.test.ts
+++ b/packages/abac/src/engine/compile.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import { compileWhere, decideCreate, getEmptyResultsWhere } from './compile.js'
+import { enrichJWT } from './enrichJWT.js'
+import type { ResolvedProvider, AttributeProvider } from '../types.js'
+
+const makeProvider = (overrides: Partial<ResolvedProvider> = {}): ResolvedProvider => {
+  return {
+    config: {
+      key: 'tenant',
+      docField: 'tenant',
+      actions: ['read', 'create', 'update', 'delete'],
+    },
+    provider: {
+      key: 'tenant',
+      fromUser: async (user) => user.tenant,
+      match: (userValue, docValue) => userValue === docValue,
+      toWhere: (userValue) => ({ tenant: { equals: userValue } }),
+    },
+    ...overrides,
+  }
+}
+
+describe('compileWhere', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+  beforeEach(() => {
+    warnSpy.mockClear()
+  })
+
+  afterEach(() => {
+    warnSpy.mockClear()
+  })
+
+  it('returns false for unauthenticated users', async () => {
+    await expect(compileWhere([], null, 'read')).resolves.toBe(false)
+  })
+
+  it('returns true when there are no applicable providers', async () => {
+    await expect(compileWhere([], { id: '1' }, 'read')).resolves.toBe(true)
+  })
+
+  it('returns a single where clause when only one provider applies', async () => {
+    const provider = makeProvider()
+
+    await expect(compileWhere([provider], { id: '1', tenant: 'tenant-a' }, 'read')).resolves.toEqual({
+      tenant: { equals: 'tenant-a' },
+    })
+  })
+
+  it('intersects multiple where clauses with an and wrapper', async () => {
+    const tenant = makeProvider()
+    const region = makeProvider({
+      config: {
+        key: 'region',
+        docField: 'region',
+        actions: ['read'],
+      },
+      provider: {
+        key: 'region',
+        fromUser: async (user) => user.region,
+        match: (userValue, docValue) => userValue === docValue,
+        toWhere: (userValue) => ({ or: [{ region: { equals: userValue } }] }),
+      },
+    })
+
+    await expect(
+      compileWhere([tenant, region], { id: '1', tenant: 'tenant-a', region: 'emea' }, 'read'),
+    ).resolves.toEqual({
+      and: [{ tenant: { equals: 'tenant-a' } }, { or: [{ region: { equals: 'emea' } }] }],
+    })
+  })
+
+  it('returns an empty-result where when the user misses a required attribute', async () => {
+    await expect(compileWhere([makeProvider()], { id: '1', tenant: null }, 'read')).resolves.toEqual(
+      getEmptyResultsWhere(),
+    )
+  })
+
+  it('treats empty arrays as missing user attributes', async () => {
+    const provider = makeProvider({
+      provider: {
+        key: 'tenant',
+        fromUser: async (user) => user.tenants,
+        match: (userValue, docValue) => Array.isArray(userValue) && userValue.includes(docValue),
+        toWhere: (userValue) => ({ tenant: { in: userValue as string[] } }),
+      },
+    })
+
+    await expect(compileWhere([provider], { id: '1', tenants: [] }, 'read')).resolves.toEqual(
+      getEmptyResultsWhere(),
+    )
+  })
+
+  it('ignores providers that do not expose toWhere', async () => {
+    const provider = makeProvider({
+      provider: {
+        key: 'tenant',
+        fromUser: async (user) => user.tenant,
+        match: (userValue, docValue) => userValue === docValue,
+      },
+    })
+
+    await expect(compileWhere([provider], { id: '1', tenant: 'tenant-a' }, 'read')).resolves.toBe(true)
+  })
+
+  it('skips providers that are not configured for the current action', async () => {
+    const provider = makeProvider({
+      config: {
+        key: 'tenant',
+        docField: 'tenant',
+        actions: ['create'],
+      },
+    })
+
+    await expect(compileWhere([provider], { id: '1', tenant: 'tenant-a' }, 'read')).resolves.toBe(true)
+  })
+
+  it('fails closed when fromUser throws', async () => {
+    const provider = makeProvider({
+      provider: {
+        key: 'tenant',
+        fromUser: async () => {
+          throw new Error('boom')
+        },
+        match: () => true,
+        toWhere: () => ({ tenant: { equals: 'tenant-a' } }),
+      },
+    })
+
+    await expect(compileWhere([provider], { id: '1' }, 'read')).resolves.toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('fails closed when toWhere throws', async () => {
+    const provider = makeProvider({
+      provider: {
+        key: 'tenant',
+        fromUser: async (user) => user.tenant,
+        match: () => true,
+        toWhere: () => {
+          throw new Error('boom')
+        },
+      },
+    })
+
+    await expect(compileWhere([provider], { id: '1', tenant: 'tenant-a' }, 'read')).resolves.toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})
+
+describe('decideCreate', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+  beforeEach(() => {
+    warnSpy.mockClear()
+  })
+
+  it('returns false for unauthenticated users', async () => {
+    await expect(decideCreate([], null, {})).resolves.toBe(false)
+  })
+
+  it('returns true when all providers match', async () => {
+    await expect(
+      decideCreate([makeProvider()], { id: '1', tenant: 'tenant-a' }, { tenant: 'tenant-a' }),
+    ).resolves.toBe(true)
+  })
+
+  it('returns false when any provider does not match', async () => {
+    await expect(
+      decideCreate([makeProvider()], { id: '1', tenant: 'tenant-a' }, { tenant: 'tenant-b' }),
+    ).resolves.toBe(false)
+  })
+
+  it('returns false when a required user value is missing', async () => {
+    await expect(decideCreate([makeProvider()], { id: '1', tenant: undefined }, { tenant: 'tenant-a' })).resolves.toBe(false)
+  })
+
+  it('reads nested values from the configured doc field', async () => {
+    const provider = makeProvider({
+      config: {
+        key: 'tenant',
+        docField: 'meta.tenant',
+        actions: ['create'],
+      },
+    })
+
+    await expect(
+      decideCreate([provider], { id: '1', tenant: 'tenant-a' }, { meta: { tenant: 'tenant-a' } }),
+    ).resolves.toBe(true)
+  })
+
+  it('skips providers that are not configured for create', async () => {
+    const provider = makeProvider({
+      config: {
+        key: 'tenant',
+        docField: 'tenant',
+        actions: ['read'],
+      },
+    })
+
+    await expect(decideCreate([provider], { id: '1', tenant: 'tenant-a' }, { tenant: 'tenant-b' })).resolves.toBe(true)
+  })
+
+  it('fails closed when match throws', async () => {
+    const provider = makeProvider({
+      provider: {
+        key: 'tenant',
+        fromUser: async (user) => user.tenant,
+        match: () => {
+          throw new Error('boom')
+        },
+        toWhere: (userValue) => ({ tenant: { equals: userValue } }),
+      },
+    })
+
+    await expect(decideCreate([provider], { id: '1', tenant: 'tenant-a' }, { tenant: 'tenant-a' })).resolves.toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})
+
+describe('enrichJWT', () => {
+  it('merges enrichJWT payloads from all providers', async () => {
+    const providers: AttributeProvider[] = [
+      {
+        key: 'tenant',
+        fromUser: async () => null,
+        match: () => true,
+        enrichJWT: async () => ({ tenant: 'tenant-a' }),
+      },
+      {
+        key: 'region',
+        fromUser: async () => null,
+        match: () => true,
+        enrichJWT: async () => ({ region: 'emea' }),
+      },
+    ]
+
+    await expect(enrichJWT(providers, { id: '1' })).resolves.toEqual({
+      tenant: 'tenant-a',
+      region: 'emea',
+    })
+  })
+
+  it('warns and lets the last value win when keys collide', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const providers: AttributeProvider[] = [
+      {
+        key: 'a',
+        fromUser: async () => null,
+        match: () => true,
+        enrichJWT: async () => ({ tenant: 'tenant-a' }),
+      },
+      {
+        key: 'b',
+        fromUser: async () => null,
+        match: () => true,
+        enrichJWT: async () => ({ tenant: 'tenant-b' }),
+      },
+    ]
+
+    await expect(enrichJWT(providers, { id: '1' })).resolves.toEqual({ tenant: 'tenant-b' })
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/packages/abac/src/engine/compile.ts
+++ b/packages/abac/src/engine/compile.ts
@@ -1,0 +1,154 @@
+import type { Where } from 'payload'
+
+import type {
+  AbacAction,
+  AbacDocument,
+  AbacUser,
+  ResolvedProvider,
+} from '../types.js'
+
+const EMPTY_RESULTS_WHERE: Where = {
+  id: {
+    exists: false,
+  },
+}
+
+const hasValue = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+
+  return value !== null && value !== undefined
+}
+
+const normalizeValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeValue(entry))
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return normalizeValue((value as { id?: unknown }).id)
+  }
+
+  return value
+}
+
+const getValueAtPath = (doc: AbacDocument, path: string): unknown => {
+  return path.split('.').reduce<unknown>((currentValue, segment) => {
+    if (currentValue && typeof currentValue === 'object' && segment in currentValue) {
+      return (currentValue as Record<string, unknown>)[segment]
+    }
+
+    return undefined
+  }, doc)
+}
+
+const getFallbackDocValue = (doc: AbacDocument, provider: ResolvedProvider): unknown => {
+  return getValueAtPath(doc, provider.config.docField)
+}
+
+const warnAndReturn = <T>(error: unknown, fallback: T): T => {
+  console.warn('[abac] provider evaluation failed, denying access', error)
+  return fallback
+}
+
+export const getEmptyResultsWhere = (): Where => EMPTY_RESULTS_WHERE
+
+export const resolveUserValue = async (
+  resolvedProvider: ResolvedProvider,
+  user: AbacUser,
+  req?: Parameters<typeof resolvedProvider.provider.fromUser>[1],
+): Promise<unknown> => {
+  return resolvedProvider.provider.fromUser(user, req as never)
+}
+
+export const compileWhere = async (
+  providers: ResolvedProvider[],
+  user: AbacUser | null | undefined,
+  action: AbacAction,
+  req?: Parameters<ResolvedProvider['provider']['fromUser']>[1],
+): Promise<Where | true | false> => {
+  if (!user) {
+    return false
+  }
+
+  if (user.isAdmin === true) {
+    return true
+  }
+
+  const whereConditions: Where[] = []
+
+  for (const resolvedProvider of providers) {
+    if (resolvedProvider.config.actions && !resolvedProvider.config.actions.includes(action)) {
+      continue
+    }
+
+    try {
+      const userValue = normalizeValue(await resolveUserValue(resolvedProvider, user, req))
+
+      if (!hasValue(userValue)) {
+        return getEmptyResultsWhere()
+      }
+
+      if (!resolvedProvider.provider.toWhere) {
+        continue
+      }
+
+      whereConditions.push(resolvedProvider.provider.toWhere(userValue))
+    } catch (error) {
+      return warnAndReturn(error, false)
+    }
+  }
+
+  if (whereConditions.length === 0) {
+    return true
+  }
+
+  if (whereConditions.length === 1) {
+    return whereConditions[0]
+  }
+
+  return {
+    and: whereConditions,
+  }
+}
+
+export const decideCreate = async (
+  providers: ResolvedProvider[],
+  user: AbacUser | null | undefined,
+  data: AbacDocument,
+  req?: Parameters<ResolvedProvider['provider']['fromUser']>[1],
+): Promise<boolean> => {
+  if (!user) {
+    return false
+  }
+
+  if (user.isAdmin === true) {
+    return true
+  }
+
+  for (const resolvedProvider of providers) {
+    if (resolvedProvider.config.actions && !resolvedProvider.config.actions.includes('create')) {
+      continue
+    }
+
+    try {
+      const userValue = normalizeValue(await resolveUserValue(resolvedProvider, user, req))
+
+      if (!hasValue(userValue)) {
+        return false
+      }
+
+      const docValue = normalizeValue(getFallbackDocValue(data, resolvedProvider))
+      const matches = await resolvedProvider.provider.match(userValue, docValue)
+
+      if (!matches) {
+        return false
+      }
+    } catch (error) {
+      return warnAndReturn(error, false)
+    }
+  }
+
+  return true
+}

--- a/packages/abac/src/engine/enrichJWT.ts
+++ b/packages/abac/src/engine/enrichJWT.ts
@@ -1,0 +1,26 @@
+import type { AbacUser, AttributeProvider } from '../types.js'
+
+export const enrichJWT = async (
+  providers: AttributeProvider[],
+  user: AbacUser,
+): Promise<Record<string, unknown>> => {
+  const enrichedPayload: Record<string, unknown> = {}
+
+  for (const provider of providers) {
+    if (!provider.enrichJWT) {
+      continue
+    }
+
+    const nextPayload = await provider.enrichJWT(user)
+
+    for (const [key, value] of Object.entries(nextPayload)) {
+      if (key in enrichedPayload) {
+        console.warn(`[abac] enrichJWT key collision for "${key}", last value wins`)
+      }
+
+      enrichedPayload[key] = value
+    }
+  }
+
+  return enrichedPayload
+}

--- a/packages/abac/src/helpers/filterOptions.ts
+++ b/packages/abac/src/helpers/filterOptions.ts
@@ -1,0 +1,23 @@
+import type { PayloadRequest, Where } from 'payload'
+
+import { getRegisteredProvider } from '../pluginContext.js'
+
+export const abacFilterOptions = (key: string) => {
+  return async ({ req }: { req: PayloadRequest }): Promise<Where | boolean> => {
+    const provider = getRegisteredProvider(key)
+
+    if (!provider || !provider.toWhere || !req.user) {
+      return true
+    }
+
+    const userValue = await provider.fromUser(req.user, req)
+
+    if (userValue === null || userValue === undefined || (Array.isArray(userValue) && userValue.length === 0)) {
+      return false
+    }
+
+    return provider.toWhere(userValue)
+  }
+}
+
+export default abacFilterOptions

--- a/packages/abac/src/index.ts
+++ b/packages/abac/src/index.ts
@@ -1,0 +1,245 @@
+import type { Access, AccessResult, CollectionConfig, Config, Endpoint, PayloadRequest, Where } from 'payload'
+
+import { compileWhere, decideCreate } from './engine/compile.js'
+import { enrichJWT } from './engine/enrichJWT.js'
+import { createMePermissionsEndpoint } from './endpoints/mePermissions.js'
+import { abacFilterOptions } from './helpers/filterOptions.js'
+import { registerProviders } from './pluginContext.js'
+import type { AbacPluginConfig } from './types.js'
+export { tenantAttribute } from './providers/tenant.js'
+export { roleAttribute } from './providers/role.js'
+export { abacFilterOptions } from './helpers/filterOptions.js'
+
+export type {
+  AbacAction,
+  AbacCollectionAttributeConfig,
+  AbacCollectionConfig,
+  AbacDocument,
+  AbacPluginConfig,
+  AbacPermissionsResponse,
+  AbacUser,
+  AttributeProvider,
+  ResolvedAttributeConfig,
+  ResolvedProvider,
+} from './types.js'
+
+const ACTIONS = ['read', 'create', 'update', 'delete'] as const
+
+type AbacAction = (typeof ACTIONS)[number]
+
+type AbacCollectionLike = CollectionConfig & {
+  custom?: {
+    abac?: Record<string, { actions?: AbacAction[]; docField: string; stampOnCreate?: boolean }>
+  }
+}
+
+const hasValue = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+
+  return value !== null && value !== undefined
+}
+
+const normalizeRelationshipValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeRelationshipValue(entry))
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return normalizeRelationshipValue((value as { id?: unknown }).id)
+  }
+
+  return value
+}
+
+const getPathValue = (value: Record<string, unknown>, path: string): unknown => {
+  return path.split('.').reduce<unknown>((currentValue, segment) => {
+    if (currentValue && typeof currentValue === 'object' && segment in currentValue) {
+      return (currentValue as Record<string, unknown>)[segment]
+    }
+
+    return undefined
+  }, value)
+}
+
+const setPathValue = (value: Record<string, unknown>, path: string, nextValue: unknown): void => {
+  const segments = path.split('.')
+  let currentValue: Record<string, unknown> = value
+
+  segments.forEach((segment, index) => {
+    if (index === segments.length - 1) {
+      currentValue[segment] = nextValue
+      return
+    }
+
+    const existingValue = currentValue[segment]
+
+    if (!existingValue || typeof existingValue !== 'object' || Array.isArray(existingValue)) {
+      currentValue[segment] = {}
+    }
+
+    currentValue = currentValue[segment] as Record<string, unknown>
+  })
+}
+
+const isIncludedCollection = (slug: string, config: AbacPluginConfig): boolean => {
+  if (config.includedCollections) {
+    return config.includedCollections.includes(slug)
+  }
+
+  if (config.excludedCollections) {
+    return !config.excludedCollections.includes(slug)
+  }
+
+  return true
+}
+
+const andAccessResults = (left: AccessResult, right: AccessResult): AccessResult => {
+  if (left === false || right === false) {
+    return false
+  }
+
+  if (left === true) {
+    return right
+  }
+
+  if (right === true) {
+    return left
+  }
+
+  return {
+    and: [left as Where, right as Where],
+  }
+}
+
+const composeAccess = (
+  previousAccess: Access | undefined,
+  computeAccess: (req: PayloadRequest, data?: Record<string, unknown>) => Promise<AccessResult>,
+): Access => {
+  return async ({ data, req }) => {
+    const previousResult = previousAccess ? await previousAccess({ data, req }) : true
+    const nextResult = await computeAccess(req, data as Record<string, unknown> | undefined)
+
+    return andAccessResults(previousResult, nextResult)
+  }
+}
+
+export const abacPlugin = (pluginConfig: AbacPluginConfig) => (incomingConfig: Config): Config => {
+  registerProviders(pluginConfig.attributes)
+
+  const providersByKey = new Map(pluginConfig.attributes.map((provider) => [provider.key, provider]))
+  const collectionProviderMap = new Map<string, { collection: AbacCollectionLike; providers: import('./types.js').ResolvedProvider[] }>()
+
+  const collections = (incomingConfig.collections ?? []).map((collection) => {
+    const nextCollection = { ...collection } as AbacCollectionLike
+
+    if (!isIncludedCollection(nextCollection.slug, pluginConfig)) {
+      return nextCollection
+    }
+
+    const collectionAbacConfig = nextCollection.custom?.abac
+
+    if (!collectionAbacConfig) {
+      return nextCollection
+    }
+
+    const resolvedProviders = Object.entries(collectionAbacConfig).map(([key, value]) => {
+      const provider = providersByKey.get(key)
+
+      if (!provider) {
+        throw new Error(`ABAC provider "${key}" referenced by collection "${nextCollection.slug}" is not registered`)
+      }
+
+      return {
+        provider,
+        config: {
+          key,
+          docField: value.docField,
+          stampOnCreate: value.stampOnCreate,
+          actions: value.actions ?? [...ACTIONS],
+        },
+      }
+    })
+
+    collectionProviderMap.set(nextCollection.slug, {
+      collection: nextCollection,
+      providers: resolvedProviders,
+    })
+
+    const previousAccess = nextCollection.access ?? {}
+
+    nextCollection.access = {
+      ...previousAccess,
+      read: composeAccess(previousAccess.read, async (req) => compileWhere(resolvedProviders, req.user, 'read', req)),
+      update: composeAccess(previousAccess.update, async (req) => compileWhere(resolvedProviders, req.user, 'update', req)),
+      delete: composeAccess(previousAccess.delete, async (req) => compileWhere(resolvedProviders, req.user, 'delete', req)),
+      create: composeAccess(previousAccess.create, async (req, data) => {
+        return (await decideCreate(resolvedProviders, req.user, data ?? {}, req)) ? true : false
+      }),
+    }
+
+    const beforeChange = async ({ data, operation, req }: { data: Record<string, unknown>; operation: string; req: PayloadRequest }) => {
+      if (operation !== 'create' || !req.user) {
+        return data
+      }
+
+      const nextData = { ...data }
+
+      for (const resolvedProvider of resolvedProviders) {
+        if (resolvedProvider.config.stampOnCreate === false) {
+          continue
+        }
+
+        const existingValue = getPathValue(nextData, resolvedProvider.config.docField)
+
+        if (hasValue(existingValue)) {
+          continue
+        }
+
+        const userValue = normalizeRelationshipValue(await resolvedProvider.provider.fromUser(req.user, req))
+
+        if (hasValue(userValue)) {
+          setPathValue(nextData, resolvedProvider.config.docField, userValue)
+        }
+      }
+
+      return nextData
+    }
+
+    nextCollection.hooks = {
+      ...nextCollection.hooks,
+      beforeChange: [beforeChange as never, ...(nextCollection.hooks?.beforeChange ?? [])],
+    }
+
+    if (nextCollection.auth) {
+      const afterLogin = async ({ req, user }: { req: PayloadRequest; user: Record<string, unknown> }) => {
+        req.user = {
+          ...(req.user ?? {}),
+          ...user,
+          ...(await enrichJWT(pluginConfig.attributes, user)),
+        } as PayloadRequest['user']
+      }
+
+      nextCollection.hooks = {
+        ...nextCollection.hooks,
+        afterLogin: [afterLogin as never, ...(nextCollection.hooks?.afterLogin ?? [])],
+      }
+    }
+
+    return nextCollection
+  })
+
+  const endpoint: Endpoint = createMePermissionsEndpoint({
+    getProvidersForCollection: (slug) => collectionProviderMap.get(slug)?.providers ?? [],
+    isCollectionEnabled: (slug) => collectionProviderMap.has(slug),
+  })
+
+  return {
+    ...incomingConfig,
+    collections,
+    endpoints: [...(incomingConfig.endpoints ?? []), endpoint],
+  }
+}
+
+export default abacPlugin

--- a/packages/abac/src/pluginContext.ts
+++ b/packages/abac/src/pluginContext.ts
@@ -1,0 +1,15 @@
+import type { AttributeProvider } from './types.js'
+
+const providerRegistry = new Map<string, AttributeProvider>()
+
+export const registerProviders = (providers: AttributeProvider[]): void => {
+  providerRegistry.clear()
+
+  for (const provider of providers) {
+    providerRegistry.set(provider.key, provider)
+  }
+}
+
+export const getRegisteredProvider = (key: string): AttributeProvider | undefined => {
+  return providerRegistry.get(key)
+}

--- a/packages/abac/src/providers/role.test.ts
+++ b/packages/abac/src/providers/role.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { roleAttribute } from './role.js'
+
+describe('roleAttribute', () => {
+  it('short-circuits for admins', async () => {
+    const provider = roleAttribute()
+    const userValue = await provider.fromUser({ isAdmin: true, userRoles: [] }, {} as never)
+
+    expect(provider.match(userValue, null)).toBe(true)
+  })
+
+  it('denies users without roles', async () => {
+    const provider = roleAttribute()
+    const userValue = await provider.fromUser({ isAdmin: false, userRoles: [] }, {} as never)
+
+    expect(provider.match(userValue, null)).toBe(false)
+  })
+
+  it('mirrors role ids into the JWT payload', async () => {
+    const provider = roleAttribute()
+
+    await expect(
+      provider.enrichJWT?.({ isAdmin: false, userRoles: [{ id: 'role-1' }] }),
+    ).resolves.toEqual({
+      isAdmin: false,
+      userRoles: [{ id: 'role-1' }],
+    })
+  })
+})

--- a/packages/abac/src/providers/role.ts
+++ b/packages/abac/src/providers/role.ts
@@ -1,0 +1,48 @@
+import type { AttributeProvider } from '../types.js'
+
+type RoleValue = {
+  isAdmin: boolean
+  roleIds: Array<number | string>
+}
+
+const getRoleIds = (user: Record<string, unknown>): Array<number | string> => {
+  const userRoles = user.userRoles
+
+  if (!Array.isArray(userRoles)) {
+    return []
+  }
+
+  return userRoles
+    .map((role) => {
+      if (role && typeof role === 'object' && 'id' in role) {
+        const roleId = (role as { id?: number | string }).id
+        return roleId ?? null
+      }
+
+      return null
+    })
+    .filter((roleId): roleId is number | string => roleId !== null)
+}
+
+export const roleAttribute = (): AttributeProvider<RoleValue, unknown> => {
+  return {
+    key: 'role',
+    fromUser: async (user) => ({
+      isAdmin: Boolean(user.isAdmin),
+      roleIds: getRoleIds(user),
+    }),
+    match: (userValue) => {
+      if (userValue.isAdmin) {
+        return true
+      }
+
+      return userValue.roleIds.length > 0
+    },
+    enrichJWT: async (user) => ({
+      userRoles: Array.isArray(user.userRoles) ? user.userRoles : [],
+      isAdmin: Boolean(user.isAdmin),
+    }),
+  }
+}
+
+export default roleAttribute

--- a/packages/abac/src/providers/tenant.test.ts
+++ b/packages/abac/src/providers/tenant.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { tenantAttribute } from './tenant.js'
+
+describe('tenantAttribute', () => {
+  it('reads the tenant from the configured user field', async () => {
+    const provider = tenantAttribute()
+
+    await expect(provider.fromUser({ tenant: 'tenant-a' }, {} as never)).resolves.toBe('tenant-a')
+  })
+
+  it('supports nested user fields', async () => {
+    const provider = tenantAttribute({ userField: 'profile.tenantId' })
+
+    await expect(
+      provider.fromUser({ profile: { tenantId: 'tenant-a' } }, {} as never),
+    ).resolves.toBe('tenant-a')
+  })
+
+  it('matches when user and doc tenant are equal', () => {
+    const provider = tenantAttribute()
+
+    expect(provider.match('tenant-a', 'tenant-a')).toBe(true)
+    expect(provider.match('tenant-a', 'tenant-b')).toBe(false)
+  })
+
+  it('denies when the user tenant is empty', () => {
+    const provider = tenantAttribute()
+
+    expect(provider.match(null, 'tenant-a')).toBe(false)
+  })
+
+  it('builds a where clause using the configured doc field', () => {
+    const provider = tenantAttribute({ docField: 'organization.tenant' })
+
+    expect(provider.toWhere?.('tenant-a')).toEqual({
+      'organization.tenant': {
+        equals: 'tenant-a',
+      },
+    })
+  })
+
+  it('enriches the JWT with the resolved tenant value', async () => {
+    const provider = tenantAttribute()
+
+    await expect(provider.enrichJWT?.({ tenant: 'tenant-a' })).resolves.toEqual({
+      tenant: 'tenant-a',
+    })
+  })
+})

--- a/packages/abac/src/providers/tenant.ts
+++ b/packages/abac/src/providers/tenant.ts
@@ -1,0 +1,45 @@
+import type { AttributeProvider } from '../types.js'
+
+type TenantAttributeOptions = {
+  userField?: string
+  docField?: string
+  jwtKey?: string
+}
+
+const getValueAtPath = (value: Record<string, unknown>, path: string): unknown => {
+  return path.split('.').reduce<unknown>((currentValue, segment) => {
+    if (currentValue && typeof currentValue === 'object' && segment in currentValue) {
+      return (currentValue as Record<string, unknown>)[segment]
+    }
+
+    return undefined
+  }, value)
+}
+
+const normalizeRelationshipValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeRelationshipValue(entry))
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return normalizeRelationshipValue((value as { id?: unknown }).id)
+  }
+
+  return value
+}
+
+export const tenantAttribute = ({
+  userField = 'tenant',
+  docField = 'tenant',
+  jwtKey = userField,
+}: TenantAttributeOptions = {}): AttributeProvider => {
+  return {
+    key: 'tenant',
+    fromUser: async (user) => normalizeRelationshipValue(getValueAtPath(user, userField) ?? null),
+    match: (userValue, docValue) => userValue != null && userValue === docValue,
+    toWhere: (userValue) => ({ [docField]: { equals: userValue } }),
+    enrichJWT: async (user) => ({ [jwtKey]: normalizeRelationshipValue(getValueAtPath(user, userField) ?? null) }),
+  }
+}
+
+export default tenantAttribute

--- a/packages/abac/src/types.ts
+++ b/packages/abac/src/types.ts
@@ -1,0 +1,52 @@
+import type { CollectionSlug, PayloadRequest, Where } from 'payload'
+
+export type AbacAction = 'read' | 'create' | 'update' | 'delete'
+
+export type AbacDocument = Record<string, unknown>
+
+export type AbacUser = Record<string, unknown> & {
+  id?: number | string
+}
+
+export type AttributeProvider<
+  UserValue = unknown,
+  DocumentValue = unknown,
+  User extends AbacUser = AbacUser,
+> = {
+  key: string
+  fromUser: (user: User, req: PayloadRequest) => UserValue | Promise<UserValue>
+  fromDoc?: Partial<Record<CollectionSlug, (doc: AbacDocument) => DocumentValue>>
+  match: (userValue: UserValue, docValue: DocumentValue) => boolean | Promise<boolean>
+  toWhere?: (userValue: UserValue) => Where
+  enrichJWT?: (user: User) => Record<string, unknown> | Promise<Record<string, unknown>>
+}
+
+export type AbacCollectionAttributeConfig = {
+  docField: string
+  stampOnCreate?: boolean
+  actions?: AbacAction[]
+}
+
+export type AbacCollectionConfig = Record<string, AbacCollectionAttributeConfig>
+
+export type AbacPluginConfig = {
+  attributes: AttributeProvider[]
+  excludedCollections?: CollectionSlug[]
+  includedCollections?: CollectionSlug[]
+  policies?: unknown
+}
+
+export type ResolvedAttributeConfig = AbacCollectionAttributeConfig & {
+  key: string
+}
+
+export type ResolvedProvider = {
+  provider: AttributeProvider
+  config: ResolvedAttributeConfig
+}
+
+export type AbacPermissionsResponse = {
+  collection: string
+  where: Where | null
+  actions: AbacAction[]
+}

--- a/packages/abac/src/types.ts
+++ b/packages/abac/src/types.ts
@@ -14,11 +14,11 @@ export type AttributeProvider<
   User extends AbacUser = AbacUser,
 > = {
   key: string
-  fromUser: (user: User, req: PayloadRequest) => UserValue | Promise<UserValue>
+  fromUser(user: User, req: PayloadRequest): UserValue | Promise<UserValue>
   fromDoc?: Partial<Record<CollectionSlug, (doc: AbacDocument) => DocumentValue>>
-  match: (userValue: UserValue, docValue: DocumentValue) => boolean | Promise<boolean>
-  toWhere?: (userValue: UserValue) => Where
-  enrichJWT?: (user: User) => Record<string, unknown> | Promise<Record<string, unknown>>
+  match(userValue: UserValue, docValue: DocumentValue): boolean | Promise<boolean>
+  toWhere?(userValue: UserValue): Where
+  enrichJWT?(user: User): Record<string, unknown> | Promise<Record<string, unknown>>
 }
 
 export type AbacCollectionAttributeConfig = {

--- a/packages/abac/tsconfig.json
+++ b/packages/abac/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "allowJs": true,
+    "checkJs": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ES6",
+    "sourceMap": true,
+    "strict": true,
+    "isolatedModules": true,
+    "target": "ESNext"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/abac/vitest.config.mts
+++ b/packages/abac/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+  },
+})

--- a/packages/authorization/src/access/general.test.ts
+++ b/packages/authorization/src/access/general.test.ts
@@ -41,6 +41,27 @@ describe('canUserAccessAction', () => {
     expect(result).toBe(false)
   })
 
+  it('supports role ids stored directly in the JWT payload', async () => {
+    const user: any = { isAdmin: false, userRoles: ['1'] }
+    const roles = [
+      {
+        permissions: [{ entity: ['articles'], type: ['read'] }],
+      },
+    ]
+
+    const payload = makePayload(roles)
+    const result = await canUserAccessAction(user, 'articles', 'read', payload, pluginConfig)
+
+    expect(result).toBe(true)
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: { in: ['1'] },
+        },
+      }),
+    )
+  })
+
   it('returns true when role grants read permission on the slug', async () => {
     const user: any = { isAdmin: false, userRoles: [{ id: '1' }] }
     const roles = [

--- a/packages/authorization/src/access/general.ts
+++ b/packages/authorization/src/access/general.ts
@@ -7,6 +7,22 @@ const PERMISSION_HIERARCHY: Record<string, string[]> = {
   read: ['read'],
 };
 
+const getUserRoleIds = (user: User): Array<number | string> => {
+  return user.userRoles
+    .map((role: any) => {
+      if (role && typeof role === 'object' && 'id' in role) {
+        return role.id ?? null;
+      }
+
+      if (typeof role === 'string' || typeof role === 'number') {
+        return role;
+      }
+
+      return null;
+    })
+    .filter((roleId): roleId is number | string => roleId !== null);
+};
+
 /**
  * Checks if a user has access to a specific action on a collection slug.
  * Optionally checks for field-level access if a fieldName is provided.
@@ -33,10 +49,14 @@ export const canUserAccessAction = async (
 
   if (!user.userRoles || user.userRoles.length === 0) return false;
 
+  const roleIds = getUserRoleIds(user);
+
+  if (roleIds.length === 0) return false;
+
   const roles = await payload.find({
     collection: config.rolesCollection,
     where: {
-      id: { in: user.userRoles.map((role: any) => role.id) },
+      id: { in: roleIds },
     },
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,15 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@20.19.24)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/abac:
+    devDependencies:
+      typescript:
+        specifier: ^5.5.2
+        version: 5.7.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@28.0.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/authorization:
     devDependencies:
       typescript:
@@ -581,6 +590,9 @@ importers:
       '@payloadcms/ui':
         specifier: 3.84.1
         version: 3.84.1(next@16.2.3(@playwright/test@1.58.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.99.0))(payload@3.84.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(types-react@19.0.0-rc.0)(typescript@5.7.3)
+      '@shefing/abac':
+        specifier: workspace:*
+        version: link:../packages/abac
       '@shefing/authorization':
         specifier: workspace:*
         version: link:../packages/authorization

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -27,6 +27,7 @@
     "@payloadcms/next": "3.84.1",
     "@payloadcms/richtext-lexical": "3.84.1",
     "@payloadcms/ui": "3.84.1",
+    "@shefing/abac": "workspace:*",
     "@shefing/authorization": "workspace:*",
     "@shefing/authors-info": "workspace:*",
     "@shefing/color-picker": "workspace:*",

--- a/test-app/src/payload-types.ts
+++ b/test-app/src/payload-types.ts
@@ -12,8 +12,12 @@
  */
 export type RolePermissions =
   | {
-      entity: ('users' | 'roles' | 'articles' | 'pages')[];
+      entity: ('tenants' | 'users' | 'roles' | 'articles' | 'pages')[];
       type: ('write' | 'read' | 'publish')[];
+      /**
+       * Restrict this permission to specific fields (leave empty for all fields)
+       */
+      fields?: string[] | null;
       id?: string | null;
     }[]
   | null;
@@ -78,6 +82,7 @@ export interface Config {
   };
   blocks: {};
   collections: {
+    tenants: Tenant;
     users: User;
     roles: Role;
     articles: Article;
@@ -90,6 +95,7 @@ export interface Config {
   };
   collectionsJoins: {};
   collectionsSelect: {
+    tenants: TenantsSelect<false> | TenantsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     roles: RolesSelect<false> | RolesSelect<true>;
     articles: ArticlesSelect<false> | ArticlesSelect<true>;
@@ -136,6 +142,19 @@ export interface UserAuthOperations {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tenants".
+ */
+export interface Tenant {
+  id: string;
+  name: string;
+  creator?: string | null;
+  updator?: string | null;
+  process?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -143,6 +162,7 @@ export interface User {
   isAdmin?: boolean | null;
   isGeneratorUser?: boolean | null;
   userRoles?: (string | Role)[] | null;
+  tenant?: (string | null) | Tenant;
   creator?: string | null;
   updator?: string | null;
   process?: string | null;
@@ -192,6 +212,7 @@ export interface Article {
   textColor?: string | null;
   bgColor?: string | null;
   icon?: string | null;
+  tenant?: (string | null) | Tenant;
   creator?: string | null;
   updator?: string | null;
   process?: string | null;
@@ -262,6 +283,10 @@ export interface PayloadLockedDocument {
   id: string;
   document?:
     | ({
+        relationTo: 'tenants';
+        value: string | Tenant;
+      } | null)
+    | ({
         relationTo: 'users';
         value: string | User;
       } | null)
@@ -325,12 +350,25 @@ export interface PayloadMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tenants_select".
+ */
+export interface TenantsSelect<T extends boolean = true> {
+  name?: T;
+  creator?: T;
+  updator?: T;
+  process?: T;
+  createdAt?: T;
+  updatedAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
   isAdmin?: T;
   isGeneratorUser?: T;
   userRoles?: T;
+  tenant?: T;
   creator?: T;
   updator?: T;
   process?: T;
@@ -374,6 +412,7 @@ export interface RolesSelect<T extends boolean = true> {
 export interface RolePermissionsSelect<T extends boolean = true> {
   entity?: T;
   type?: T;
+  fields?: T;
   id?: T;
 }
 /**
@@ -385,6 +424,7 @@ export interface ArticlesSelect<T extends boolean = true> {
   textColor?: T;
   bgColor?: T;
   icon?: T;
+  tenant?: T;
   creator?: T;
   updator?: T;
   process?: T;

--- a/test-app/src/payload.config.ts
+++ b/test-app/src/payload.config.ts
@@ -6,6 +6,7 @@ import sharp from 'sharp'
 import { fileURLToPath } from 'url'
 
 // ── Plugin imports ────────────────────────────────────────────────────────────
+import { abacPlugin, roleAttribute, tenantAttribute } from '@shefing/abac'
 import { addAccess, Roles, userFields } from '@shefing/authorization'
 import { addAuthorsFields as addAuthorsInfo } from '@shefing/authors-info'
 import { createColorField, createBackgroundColorField } from '@shefing/color-picker'
@@ -41,6 +42,20 @@ export default buildConfig({
   },
 
   collections: [
+    {
+      slug: 'tenants',
+      admin: {
+        useAsTitle: 'name',
+      },
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+
     // ── Users (required by authorization plugin) ──────────────────────────
     {
       slug: 'users',
@@ -50,7 +65,15 @@ export default buildConfig({
       auth: {
         useAPIKey: true,
       },
-      fields: [...userFields],
+      fields: [
+        ...userFields,
+        {
+          name: 'tenant',
+          type: 'relationship',
+          relationTo: 'tenants',
+          saveToJWT: true,
+        },
+      ],
     },
 
     // ── Roles (from authorization plugin) ───────────────────────────────────
@@ -60,7 +83,14 @@ export default buildConfig({
     {
       slug: 'articles',
       admin: {
-        defaultColumns: ['title', 'bgColor', 'textColor', 'icon'],
+        defaultColumns: ['title', 'tenant', 'bgColor', 'textColor', 'icon'],
+      },
+      custom: {
+        abac: {
+          tenant: {
+            docField: 'tenant',
+          },
+        },
       },
       versions: {
         drafts: true,
@@ -75,6 +105,11 @@ export default buildConfig({
         createColorField({ name: 'textColor', label: 'Text Color' }),
         createBackgroundColorField({ name: 'bgColor', label: 'Background Color' }),
         createIconSelectField({ name: 'icon', label: 'Icon' }),
+        {
+          name: 'tenant',
+          type: 'relationship',
+          relationTo: 'tenants',
+        },
       ],
     },
 
@@ -132,6 +167,10 @@ export default buildConfig({
     addAccess({
       rolesCollection: 'roles',
       permissionsField: 'permissions',
+      excludedCollections: ['media'],
+    }),
+    abacPlugin({
+      attributes: [tenantAttribute(), roleAttribute()],
       excludedCollections: ['media'],
     }),
     // CommentsPlugin({}),

--- a/test-app/src/seed.ts
+++ b/test-app/src/seed.ts
@@ -5,9 +5,27 @@ export const adminUser = {
   password: 'Password1!',
 }
 
+export const tenantUsers = {
+  alice: {
+    email: 'alice@tenant-a.dev',
+    password: 'Password1!',
+    apiKey: 'tenant-a-api-key',
+  },
+  bob: {
+    email: 'bob@tenant-b.dev',
+    password: 'Password1!',
+    apiKey: 'tenant-b-api-key',
+  },
+}
+
 export const seed = async (payload: Payload) => {
   // ── Roles ───────────────────────────────────────────────────────────────────
   let adminRoleId: string | undefined
+  let editorRoleId: string | undefined
+  const editorPermissions = [
+    { entity: ['articles', 'pages'], type: ['read', 'write', 'publish'] },
+  ]
+  const viewerPermissions = [{ entity: ['articles', 'pages'], type: ['read'] }]
   const { totalDocs: roleCount } = await payload.count({ collection: 'roles', overrideAccess: true })
   if (!roleCount) {
     const adminRole = await payload.create({
@@ -16,35 +34,86 @@ export const seed = async (payload: Payload) => {
       overrideAccess: true,
     })
     adminRoleId = String(adminRole.id)
-    await payload.create({
+    const editorRole = await payload.create({
       collection: 'roles',
       overrideAccess: true,
       data: {
         name: 'editor',
-        permissions: [
-          { entity: ['articles', 'pages'], type: ['read', 'write', 'publish'] },
-        ],
+        permissions: editorPermissions,
       },
     })
+    editorRoleId = String(editorRole.id)
     await payload.create({
       collection: 'roles',
       overrideAccess: true,
       data: {
         name: 'viewer',
-        permissions: [
-          { entity: ['articles', 'pages'], type: ['read'] },
-        ],
+        permissions: viewerPermissions,
       },
     })
     payload.logger.info('Seed: roles created')
   } else {
     const existing = await payload.find({
       collection: 'roles',
-      where: { name: { equals: 'admin' } },
+      where: { name: { in: ['admin', 'editor', 'viewer'] } },
+      limit: 10,
+      overrideAccess: true,
+    })
+
+    for (const role of existing.docs) {
+      if (role.name === 'admin') {
+        adminRoleId = String(role.id)
+      }
+
+      if (role.name === 'editor') {
+        editorRoleId = String(role.id)
+
+        await payload.update({
+          collection: 'roles',
+          id: role.id,
+          data: {
+            permissions: editorPermissions,
+          },
+          overrideAccess: true,
+        })
+      }
+
+      if (role.name === 'viewer') {
+        await payload.update({
+          collection: 'roles',
+          id: role.id,
+          data: {
+            permissions: viewerPermissions,
+          },
+          overrideAccess: true,
+        })
+      }
+    }
+  }
+
+  // ── Tenants ─────────────────────────────────────────────────────────────────
+  const tenantIds: Record<string, string> = {}
+
+  for (const name of ['tenant-a', 'tenant-b']) {
+    const existingTenant = await payload.find({
+      collection: 'tenants',
+      where: { name: { equals: name } },
       limit: 1,
       overrideAccess: true,
     })
-    if (existing.docs.length) adminRoleId = String(existing.docs[0].id)
+
+    if (existingTenant.docs.length) {
+      tenantIds[name] = String(existingTenant.docs[0].id)
+      continue
+    }
+
+    const tenant = await payload.create({
+      collection: 'tenants',
+      data: { name },
+      overrideAccess: true,
+    })
+
+    tenantIds[name] = String(tenant.id)
   }
 
   // ── Admin user ──────────────────────────────────────────────────────────────
@@ -80,11 +149,65 @@ export const seed = async (payload: Payload) => {
     })
   }
 
+  // ── Tenant users ────────────────────────────────────────────────────────────
+  for (const [tenantName, user] of [
+    ['tenant-a', tenantUsers.alice],
+    ['tenant-b', tenantUsers.bob],
+  ] as const) {
+    const existing = await payload.find({
+      collection: 'users',
+      where: { email: { equals: user.email } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    const userData = {
+      email: user.email,
+      password: user.password,
+      enableAPIKey: true,
+      apiKey: user.apiKey,
+      isAdmin: false,
+      userRoles: editorRoleId ? [editorRoleId] : [],
+      tenant: tenantIds[tenantName],
+    }
+
+    if (!existing.docs.length) {
+      await payload.create({
+        collection: 'users',
+        data: userData,
+        overrideAccess: true,
+      })
+    } else {
+      await payload.update({
+        collection: 'users',
+        data: userData,
+        where: { email: { equals: user.email } },
+        overrideAccess: true,
+      })
+    }
+  }
+
   // ── Sample articles (exercises color-picker, icon-select) ───────────────────
   // Only create seed articles if they don't already exist (avoid wiping E2E test data)
   const seedArticles = [
     { title: 'Hello World', textColor: 'blue-500', bgColor: 'gray-100', icon: 'star', _status: 'published' as const },
     { title: 'Second Article', textColor: 'red-600', bgColor: 'white', icon: 'heart', _status: 'draft' as const },
+    {
+      title: 'Tenant A Article',
+      textColor: 'green-500',
+      bgColor: 'gray-100',
+      icon: 'star',
+      tenant: tenantIds['tenant-a'],
+      _status: 'published' as const,
+    },
+    {
+      title: 'Tenant B Article',
+      textColor: 'purple-500',
+      bgColor: 'white',
+      icon: 'heart',
+      tenant: tenantIds['tenant-b'],
+      _status: 'published' as const,
+    },
   ]
   for (const articleData of seedArticles) {
     const existing = await payload.find({

--- a/test-app/src/seed.ts
+++ b/test-app/src/seed.ts
@@ -1,5 +1,7 @@
 import type { Payload } from 'payload'
 
+import type { RolePermissions } from './payload-types'
+
 export const adminUser = {
   email: 'admin@payload-tools.dev',
   password: 'Password1!',
@@ -22,10 +24,10 @@ export const seed = async (payload: Payload) => {
   // ── Roles ───────────────────────────────────────────────────────────────────
   let adminRoleId: string | undefined
   let editorRoleId: string | undefined
-  const editorPermissions = [
+  const editorPermissions: RolePermissions = [
     { entity: ['articles', 'pages'], type: ['read', 'write', 'publish'] },
   ]
-  const viewerPermissions = [{ entity: ['articles', 'pages'], type: ['read'] }]
+  const viewerPermissions: RolePermissions = [{ entity: ['articles', 'pages'], type: ['read'] }]
   const { totalDocs: roleCount } = await payload.count({ collection: 'roles', overrideAccess: true })
   if (!roleCount) {
     const adminRole = await payload.create({

--- a/test-app/tests/e2e-plugins/abac.spec.ts
+++ b/test-app/tests/e2e-plugins/abac.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test'
 
+import { login } from './helpers'
+
 const tenantUsers = {
   alice: {
     email: 'alice@tenant-a.dev',
@@ -101,8 +103,7 @@ test.describe('abac plugin (@shefing/abac)', () => {
   }
 
   test('admin UI list remains reachable and shows article rows', async ({ page }) => {
-    await page.goto('/admin')
-    await page.waitForURL((url) => url.pathname === '/admin', { timeout: 30000 })
+    await login(page)
 
     await page.goto('/admin/collections/articles')
     await page.waitForLoadState('networkidle', { timeout: 30000 })

--- a/test-app/tests/e2e-plugins/abac.spec.ts
+++ b/test-app/tests/e2e-plugins/abac.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test'
+
+const tenantUsers = {
+  alice: {
+    email: 'alice@tenant-a.dev',
+    password: 'Password1!',
+  },
+  bob: {
+    email: 'bob@tenant-b.dev',
+    password: 'Password1!',
+  },
+}
+
+const loginViaRest = async (request: Parameters<typeof test>[0]['request'], email: string, password: string) => {
+  const loginRes = await request.post('/api/users/login', {
+    data: { email, password },
+  })
+
+  expect(loginRes.ok()).toBeTruthy()
+
+  const body = await loginRes.json()
+  const [, payload] = (body.token as string).split('.')
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as {
+    tenant?: string
+  }
+
+  return {
+    token: body.token as string,
+    tenantId: String(decoded.tenant),
+  }
+}
+
+test.describe('abac plugin (@shefing/abac)', () => {
+  for (const [label, user] of Object.entries(tenantUsers)) {
+    test(`${label} only sees their tenant documents via REST`, async ({ request }) => {
+      const { token, tenantId } = await loginViaRest(request, user.email, user.password)
+
+      const listRes = await request.get('/api/articles', {
+        headers: { Authorization: `JWT ${token}` },
+      })
+
+      expect(listRes.status()).toBe(200)
+
+      const listBody = await listRes.json()
+      const docs = listBody.docs as Array<{ tenant?: { id?: string } | string | null }>
+      const restTitles = docs.map((doc: { title?: string }) => doc.title).filter(Boolean)
+
+      expect(
+        docs.every((doc) => {
+          if (!doc.tenant) {
+            return false
+          }
+
+          const docTenantId = typeof doc.tenant === 'string' ? doc.tenant : doc.tenant.id
+          return String(docTenantId) === tenantId
+        }),
+      ).toBe(true)
+    })
+
+    test(`${label} gets tenant-scoped permissions and GraphQL results`, async ({ request }) => {
+      const { token, tenantId } = await loginViaRest(request, user.email, user.password)
+
+      const listRes = await request.get('/api/articles', {
+        headers: { Authorization: `JWT ${token}` },
+      })
+
+      expect(listRes.status()).toBe(200)
+
+      const listBody = await listRes.json()
+      const restTitles = (listBody.docs as Array<{ title?: string }>).map((doc) => doc.title).filter(Boolean)
+
+      const permissionsRes = await request.get('/api/me/permissions?collection=articles', {
+        headers: { Authorization: `JWT ${token}` },
+      })
+
+      expect(permissionsRes.status()).toBe(200)
+
+      const permissionsBody = await permissionsRes.json()
+      expect(permissionsBody.collection).toBe('articles')
+      expect(permissionsBody.actions).toContain('read')
+      expect(permissionsBody.where).toEqual({ tenant: { equals: tenantId } })
+
+      const graphqlRes = await request.post('/api/graphql', {
+        headers: { Authorization: `JWT ${token}` },
+        data: {
+          query: `query Articles { Articles { docs { title tenant { id } } } }`,
+        },
+      })
+
+      expect(graphqlRes.status()).toBe(200)
+
+      const graphqlBody = await graphqlRes.json()
+      const docs = graphqlBody.data.Articles.docs as Array<{
+        title?: string
+        tenant?: { id?: string } | string | null
+      }>
+      const graphQlTitles = docs.map((doc) => doc.title).filter(Boolean)
+
+      expect(graphQlTitles.sort()).toEqual(restTitles.sort())
+    })
+  }
+
+  test('admin UI list remains reachable and shows article rows', async ({ page }) => {
+    await page.goto('/admin')
+    await page.waitForURL((url) => url.pathname === '/admin', { timeout: 30000 })
+
+    await page.goto('/admin/collections/articles')
+    await page.waitForLoadState('networkidle', { timeout: 30000 })
+
+    await expect(page.getByRole('heading', { name: 'Articles' })).toBeVisible()
+    const rows = page.locator('tbody tr')
+    await expect(rows.first()).toBeVisible()
+    expect(await rows.count()).toBeGreaterThan(0)
+  })
+})

--- a/test-app/tests/int/abac.int.spec.ts
+++ b/test-app/tests/int/abac.int.spec.ts
@@ -1,0 +1,146 @@
+import { createLocalReq, getPayload, Payload } from 'payload'
+import config from '@/payload.config'
+
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { adminUser, tenantUsers } from '@/seed'
+
+let payload: Payload
+let payloadConfig: Awaited<typeof config>
+
+const findUserByEmail = async (email: string) => {
+  const result = await payload.find({
+    collection: 'users',
+    where: { email: { equals: email } },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  return result.docs[0]
+}
+
+const findArticleByTitle = async (title: string) => {
+  const result = await payload.find({
+    collection: 'articles',
+    where: { title: { equals: title } },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  return result.docs[0]
+}
+
+const getArticlesCollection = () => {
+  return payloadConfig.collections?.find((collection) => collection.slug === 'articles')
+}
+
+const createReqForUser = async (user: Record<string, any>, urlSuffix = '') => {
+  const req = await createLocalReq({ user, urlSuffix }, payload)
+
+  req.user = user
+  req.payload = payload
+
+  if (req.url) {
+    req.searchParams = new URL(req.url).searchParams
+  }
+
+  return req
+}
+
+describe('ABAC integration', () => {
+  beforeAll(async () => {
+    payloadConfig = await config
+    payload = await getPayload({ config: payloadConfig })
+  })
+
+  it('scopes article reads to the current tenant', async () => {
+    const alice = await findUserByEmail(tenantUsers.alice.email)
+    const req = await createReqForUser(alice)
+    const articlesCollection = getArticlesCollection()
+
+    expect(articlesCollection).toBeDefined()
+
+    const rolesCheck = await payload.find({
+      collection: 'roles',
+      where: {
+        id: {
+          in: alice.userRoles.map((role: { id: string }) => role.id),
+        },
+      },
+      overrideAccess: true,
+    })
+
+    expect(rolesCheck.docs.length).toBeGreaterThan(0)
+
+    await expect(articlesCollection!.access!.read!({ req })).resolves.toEqual({
+      tenant: { equals: String(alice.tenant.id) },
+    })
+  })
+
+  it('rejects cross-tenant creates', async () => {
+    const alice = await findUserByEmail(tenantUsers.alice.email)
+    const tenantBArticle = await findArticleByTitle('Tenant B Article')
+    const req = await createReqForUser(alice)
+    const articlesCollection = getArticlesCollection()
+
+    expect(articlesCollection).toBeDefined()
+
+    await expect(
+      articlesCollection!.access!.create!({
+        req,
+        data: {
+          title: 'Cross Tenant Create',
+          tenant: tenantBArticle.tenant.id,
+        },
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it('stamps the tenant on create when omitted', async () => {
+    const alice = await findUserByEmail(tenantUsers.alice.email)
+    const req = await createReqForUser(alice)
+    const articlesCollection = getArticlesCollection()
+
+    expect(articlesCollection).toBeDefined()
+
+    const beforeChangeResult = await articlesCollection!.hooks.beforeChange?.[0]({
+      req,
+      operation: 'create',
+      data: {
+        title: `Stamped Tenant Article ${Date.now()}`,
+      },
+    })
+
+    expect(beforeChangeResult).toMatchObject({
+      tenant: String(alice.tenant.id),
+    })
+  })
+
+  it('returns permissions through the endpoint handler', async () => {
+    const alice = await findUserByEmail(tenantUsers.alice.email)
+    const req = await createReqForUser(alice, '/api/me/permissions?collection=articles')
+
+    const endpoint = payloadConfig.endpoints?.find((entry) => entry.path === '/me/permissions')
+
+    expect(endpoint).toBeDefined()
+
+    const response = await endpoint!.handler(req)
+
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.collection).toBe('articles')
+    expect(body.where).toBeTruthy()
+    expect(body.actions).toContain('read')
+  })
+
+  it('does not constrain admins', async () => {
+    const admin = await findUserByEmail(adminUser.email)
+    const req = await createReqForUser(admin)
+    const articlesCollection = getArticlesCollection()
+
+    expect(articlesCollection).toBeDefined()
+
+    await expect(articlesCollection!.access!.read!({ req })).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
### Summary
- add the new `@shefing/abac` package with a pluggable attribute-based access engine, built-in `tenant` and `role` providers, JWT enrichment, relationship filter helper, and `/api/me/permissions` endpoint
- wire the ABAC plugin into `test-app` with tenant-aware collections, seeding, integration coverage, and Playwright e2e coverage
- fix authorization role resolution for JWT-stored role IDs so ABAC + existing RBAC compose correctly over HTTP

### Verification
- `pnpm exec vitest run packages/authorization/src/access/general.test.ts`
- `cd test-app && pnpm test:e2e -- tests/e2e-plugins/abac.spec.ts`

### Notes
- Step 5 remains marked failed in the session plan because one local Vitest read-path mismatch was user-accepted as a blocker earlier in the session, but the HTTP/e2e coverage for Step 6 is now green.