### PR TITLE
fix(authors-info): only stamp publishedAt on draft→published transition

### DIFF
--- a/packages/authors-info/package.json
+++ b/packages/authors-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shefing/authors-info",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "private": false,
   "bugs": "https://github.com/shefing/payload-tools/issues",
   "repository": "https://github.com/shefing/payload-tools",

--- a/packages/authors-info/src/hooks/setAuthorsData.ts
+++ b/packages/authors-info/src/hooks/setAuthorsData.ts
@@ -40,7 +40,7 @@ export const setAuthorsData = (
           }
           break;
         case 'update':
-          if (args?.data._status === 'published') {
+          if (args?.data._status === 'published' && args?.originalDoc?._status !== 'published') {
             args.data[publishedAtFieldName] = new Date();
             args.data[publishedByFieldName] = args.req.user?.[usernameField] || 'system';
           }


### PR DESCRIPTION
Fixes #206

## Problem
`setAuthorsData`'s `beforeChange` hook was re-stamping `publishedAt` (`publishDate`) on **every** update to an already-published doc, because it only checked `data._status === 'published'` without verifying the previous state.

## Fix
Added a check against `originalDoc._status` so `publishedAt` and `publishedBy` are only set on a true **draft → published** transition:

```ts
case 'update':
  if (args?.data._status === 'published' && args?.originalDoc?._status !== 'published') {
    args.data[publishedAtFieldName] = new Date();
    args.data[publishedByFieldName] = args.req.user?.[usernameField] || 'system';
  }
  break;
```

## Version
Bumped `@shefing/authors-info` from `1.0.32` → `1.0.33`.